### PR TITLE
Rename properties to relations throughout codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/human-language/issues/12
-Your prepared branch: issue-12-85b2b0cb
-Your prepared working directory: /tmp/gh-issue-solver-1757530156248
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/human-language/issues/12
+Your prepared branch: issue-12-85b2b0cb
+Your prepared working directory: /tmp/gh-issue-solver-1757530156248
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Human Language Project
 
-> A sophisticated web application for transforming natural language into Wikidata entity and property sequences, enabling semantic understanding and knowledge representation.
+> A sophisticated web application for transforming natural language into Wikidata entity and relation sequences, enabling semantic understanding and knowledge representation.
 
 ## 🎯 Vision
 
-The Human Language project aims to create a universal meta-language that bridges all human languages by leveraging Wikidata's semantic knowledge graph. By converting natural language into sequences of entities (Q) and properties (P), we enable:
+The Human Language project aims to create a universal meta-language that bridges all human languages by leveraging Wikidata's semantic knowledge graph. By converting natural language into sequences of entities (Q) and relations (P), we enable:
 
 - **Cross-linguistic understanding**: Unified representation across all languages
 - **Semantic precision**: Disambiguation of concepts using Wikidata's rich ontology
@@ -31,12 +31,12 @@ This project will fundamentally transform how we store, access, and verify human
 - **Real-time transformation**: Interactive web demo at `transformation/index.html`
 - [Learn more →](transformation/README.md)
 
-### 2. Entity & Property Viewer
+### 2. Entity & Relations Viewer
 - **Beautiful UI**: Modern, responsive interface with dark/light themes
 - **Multi-language support**: Automatic language detection and switching
-- **Rich statements display**: View all properties and relationships
+- **Rich statements display**: View all relations and relationships
 - **Direct Wikidata links**: Seamlessly navigate to source data
-- View entities at `entities.html` and properties at `properties.html`
+- View entities at `entities.html` and relations at `properties.html`
 
 ### 3. Advanced Search & Disambiguation
 - **Exact & fuzzy matching**: Find entities even with typos

--- a/data/wikidata-cache/021e2851bfc9059bd272088515dd76e7.json
+++ b/data/wikidata-cache/021e2851bfc9059bd272088515dd76e7.json
@@ -36,7 +36,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -47,7 +47,7 @@
         "description": "president of the United States from 2009 to 2017",
         "match": {
           "type": "alias",
-          "language": "en",
+          "language": "mul",
           "text": "Obama"
         },
         "aliases": [
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619265623,
+  "timestamp": 1757530492113,
   "ttl": 86400000,
   "query": "Obama",
   "languages": "en",

--- a/data/wikidata-cache/027b7e9d661470e337fdaca515a98374.json
+++ b/data/wikidata-cache/027b7e9d661470e337fdaca515a98374.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610222,
+  "timestamp": 1757530494368,
   "ttl": 86400000,
   "query": "fuzzy_theory of",
   "languages": "en",

--- a/data/wikidata-cache/02b42ca1855ea99d435ec2fd5c28590f.json
+++ b/data/wikidata-cache/02b42ca1855ea99d435ec2fd5c28590f.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609665,
+  "timestamp": 1757530494124,
   "ttl": 86400000,
   "query": "fuzzy_Einstein discovered the",
   "languages": "en",

--- a/data/wikidata-cache/04dd57a4d8c6ea5b75b85b5299af0d8b.json
+++ b/data/wikidata-cache/04dd57a4d8c6ea5b75b85b5299af0d8b.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6347",
         "title": "Property:P6347",
@@ -163,7 +163,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634608836,
+  "timestamp": 1757530493525,
   "ttl": 86400000,
   "query": "fuzzy_the White",
   "languages": "en",

--- a/data/wikidata-cache/05aa8d1d8fcf7e98567de144bf7d6397.json
+++ b/data/wikidata-cache/05aa8d1d8fcf7e98567de144bf7d6397.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P800",
         "title": "Property:P800",
@@ -92,7 +92,7 @@
     ],
     "total": 3
   },
-  "timestamp": 1753634618038,
+  "timestamp": 1757530499453,
   "ttl": 86400000,
   "query": "fuzzy_wrote",
   "languages": "en",

--- a/data/wikidata-cache/05fbe8ee90c47299500986a68bcf856b.json
+++ b/data/wikidata-cache/05fbe8ee90c47299500986a68bcf856b.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616912,
+  "timestamp": 1757530498547,
   "ttl": 86400000,
   "query": "fuzzy_became the President",
   "languages": "en",

--- a/data/wikidata-cache/06a1d4fb3c81dbaa396c1869790b6278.json
+++ b/data/wikidata-cache/06a1d4fb3c81dbaa396c1869790b6278.json
@@ -131,10 +131,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634615436,
+  "timestamp": 1757530497410,
   "ttl": 86400000,
   "query": "fuzzy_United Nations Secretary",
   "languages": "en",

--- a/data/wikidata-cache/07a5a18641ce7dee3594dac64ad082b0.json
+++ b/data/wikidata-cache/07a5a18641ce7dee3594dac64ad082b0.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P575",
         "title": "Property:P575",
@@ -121,7 +121,7 @@
     ],
     "total": 4
   },
-  "timestamp": 1753634609562,
+  "timestamp": 1757530494091,
   "ttl": 86400000,
   "query": "fuzzy_discovered",
   "languages": "en",

--- a/data/wikidata-cache/07b8001bdd90782a3f4c86544c653cb3.json
+++ b/data/wikidata-cache/07b8001bdd90782a3f4c86544c653cb3.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610386,
+  "timestamp": 1757530494526,
   "ttl": 86400000,
   "query": "fuzzy_theory of relativity",
   "languages": "en",

--- a/data/wikidata-cache/07e560569d0796b3731ef0dfe26025fd.json
+++ b/data/wikidata-cache/07e560569d0796b3731ef0dfe26025fd.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634616248,
+  "timestamp": 1757530498049,
   "ttl": 86400000,
   "query": "became the",
   "languages": "en",

--- a/data/wikidata-cache/0833676c4e5a73506b7cd990a19aedad.json
+++ b/data/wikidata-cache/0833676c4e5a73506b7cd990a19aedad.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613171,
+  "timestamp": 1757530496268,
   "ttl": 86400000,
   "query": "fuzzy_of America president",
   "languages": "en",

--- a/data/wikidata-cache/086202287f78edac54de4bdb02be2907.json
+++ b/data/wikidata-cache/086202287f78edac54de4bdb02be2907.json
@@ -127,7 +127,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P9371",
         "title": "Property:P9371",
@@ -264,7 +264,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634611850,
+  "timestamp": 1757530495481,
   "ttl": 86400000,
   "query": "fuzzy_France",
   "languages": "en",

--- a/data/wikidata-cache/08c94493523bb178c847d489defe6f89.json
+++ b/data/wikidata-cache/08c94493523bb178c847d489defe6f89.json
@@ -131,10 +131,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634615473,
+  "timestamp": 1757530497613,
   "ttl": 86400000,
   "query": "fuzzy_United Nations Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/091118e49785da803b11def3f952d916.json
+++ b/data/wikidata-cache/091118e49785da803b11def3f952d916.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617990,
+  "timestamp": 1757530499439,
   "ttl": 86400000,
   "query": "fuzzy_wrote Romeo",
   "languages": "en",

--- a/data/wikidata-cache/10031eed15ec47230bdcd5013314ed66.json
+++ b/data/wikidata-cache/10031eed15ec47230bdcd5013314ed66.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616971,
+  "timestamp": 1757530498547,
   "ttl": 86400000,
   "query": "fuzzy_the United States",
   "languages": "en",

--- a/data/wikidata-cache/119cf773e0d23fc3f66de461beddc456.json
+++ b/data/wikidata-cache/119cf773e0d23fc3f66de461beddc456.json
@@ -136,7 +136,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P35",
         "title": "Property:P35",
@@ -169,7 +169,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634613212,
+  "timestamp": 1757530496426,
   "ttl": 86400000,
   "query": "fuzzy_States",
   "languages": "en",

--- a/data/wikidata-cache/11d20b6b4bf56495b5f54ced3407a95c.json
+++ b/data/wikidata-cache/11d20b6b4bf56495b5f54ced3407a95c.json
@@ -127,7 +127,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P8795",
         "title": "Property:P8795",
@@ -212,7 +212,7 @@
     ],
     "total": 8
   },
-  "timestamp": 1753634609571,
+  "timestamp": 1757530494075,
   "ttl": 86400000,
   "query": "Albert",
   "languages": "en",

--- a/data/wikidata-cache/126ea498b09b89f22bc3b29bada39738.json
+++ b/data/wikidata-cache/126ea498b09b89f22bc3b29bada39738.json
@@ -136,7 +136,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P36",
         "title": "Property:P36",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634611813,
+  "timestamp": 1757530495385,
   "ttl": 86400000,
   "query": "fuzzy_capital",
   "languages": "en",

--- a/data/wikidata-cache/129eb2788bef0c0c4aca07c33715ca15.json
+++ b/data/wikidata-cache/129eb2788bef0c0c4aca07c33715ca15.json
@@ -136,10 +136,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608798,
+  "timestamp": 1757530493593,
   "ttl": 86400000,
   "query": "fuzzy_White House",
   "languages": "en",

--- a/data/wikidata-cache/137dd7027e39ab7840b2b83bd9f060e1.json
+++ b/data/wikidata-cache/137dd7027e39ab7840b2b83bd9f060e1.json
@@ -133,7 +133,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P4636",
         "title": "Property:P4636",
@@ -166,7 +166,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634618004,
+  "timestamp": 1757530499426,
   "ttl": 86400000,
   "query": "Juliet",
   "languages": "en",

--- a/data/wikidata-cache/15ec0cb006c703a7e4fa0ac5f5b886e5.json
+++ b/data/wikidata-cache/15ec0cb006c703a7e4fa0ac5f5b886e5.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P2388",
         "title": "Property:P2388",
@@ -195,7 +195,7 @@
     ],
     "total": 7
   },
-  "timestamp": 1753634614814,
+  "timestamp": 1757530497067,
   "ttl": 86400000,
   "query": "Secretary",
   "languages": "en",

--- a/data/wikidata-cache/16d54154bda72ffe782f25d63a8b0f70.json
+++ b/data/wikidata-cache/16d54154bda72ffe782f25d63a8b0f70.json
@@ -23,10 +23,10 @@
         "match": {
           "type": "alias",
           "language": "en",
-          "text": "United States of America"
+          "text": "United States of North America"
         },
         "aliases": [
-          "United States of America"
+          "United States of North America"
         ]
       },
       {
@@ -139,10 +139,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634613207,
+  "timestamp": 1757530496368,
   "ttl": 86400000,
   "query": "fuzzy_United States of",
   "languages": "en",

--- a/data/wikidata-cache/19ccdaa3b6b56d54bcc3db043b65eaae.json
+++ b/data/wikidata-cache/19ccdaa3b6b56d54bcc3db043b65eaae.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606370,
+  "timestamp": 1757530491964,
   "ttl": 86400000,
   "query": "was born",
   "languages": "en",

--- a/data/wikidata-cache/1babb4641737cf96f0f31021c6b66cf9.json
+++ b/data/wikidata-cache/1babb4641737cf96f0f31021c6b66cf9.json
@@ -30,10 +30,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634611100,
+  "timestamp": 1757530495006,
   "ttl": 86400000,
   "query": "of France",
   "languages": "en",

--- a/data/wikidata-cache/1be2103512edd71c8ae2302fb07fdd3d.json
+++ b/data/wikidata-cache/1be2103512edd71c8ae2302fb07fdd3d.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P1376",
         "title": "Property:P1376",
@@ -141,7 +141,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753619280566,
+  "timestamp": 1757530494815,
   "ttl": 86400000,
   "query": "Paris",
   "languages": "en",

--- a/data/wikidata-cache/1da8a583233ed807e708d3510248dcd1.json
+++ b/data/wikidata-cache/1da8a583233ed807e708d3510248dcd1.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616634,
+  "timestamp": 1757530498090,
   "ttl": 86400000,
   "query": "President of",
   "languages": "en",

--- a/data/wikidata-cache/1e62a7fee776ce4c532108521e58cb01.json
+++ b/data/wikidata-cache/1e62a7fee776ce4c532108521e58cb01.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609204,
+  "timestamp": 1757530493795,
   "ttl": 86400000,
   "query": "Einstein discovered",
   "languages": "en",

--- a/data/wikidata-cache/1e66f3dfe0fb4c65fb326c410075f114.json
+++ b/data/wikidata-cache/1e66f3dfe0fb4c65fb326c410075f114.json
@@ -130,7 +130,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1225",
         "title": "Property:P1225",
@@ -199,7 +199,7 @@
         "url": "//www.wikidata.org/wiki/Property:P7063",
         "display": {
           "label": {
-            "value": "U. S. Supreme Court docket number",
+            "value": "U.S. Supreme Court docket number",
             "language": "en"
           },
           "description": {
@@ -207,7 +207,7 @@
             "language": "en"
           }
         },
-        "label": "U. S. Supreme Court docket number",
+        "label": "U.S. Supreme Court docket number",
         "description": "identifier for a case filed at the Supreme Court of the United States",
         "match": {
           "type": "alias",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634612558,
+  "timestamp": 1757530495951,
   "ttl": 86400000,
   "query": "United States",
   "languages": "en",

--- a/data/wikidata-cache/1f687bf45ac70d3234db238062c5bc60.json
+++ b/data/wikidata-cache/1f687bf45ac70d3234db238062c5bc60.json
@@ -36,7 +36,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -47,7 +47,7 @@
         "description": "president of the United States from 2009 to 2017",
         "match": {
           "type": "alias",
-          "language": "en",
+          "language": "mul",
           "text": "Obama"
         },
         "aliases": [
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619266338,
+  "timestamp": 1757530492578,
   "ttl": 86400000,
   "query": "fuzzy_Obama",
   "languages": "en",

--- a/data/wikidata-cache/1fc23eee2a027a12dca509ded0281e7f.json
+++ b/data/wikidata-cache/1fc23eee2a027a12dca509ded0281e7f.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609549,
+  "timestamp": 1757530494046,
   "ttl": 86400000,
   "query": "Albert Einstein",
   "languages": "en",

--- a/data/wikidata-cache/213fdd82b1cc99482b64e84f1f4834ab.json
+++ b/data/wikidata-cache/213fdd82b1cc99482b64e84f1f4834ab.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P53",
         "title": "Property:P53",
@@ -273,7 +273,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634608192,
+  "timestamp": 1757530493169,
   "ttl": 86400000,
   "query": "House",
   "languages": "en",

--- a/data/wikidata-cache/21833b9cdde1793788e59121f34b5b7e.json
+++ b/data/wikidata-cache/21833b9cdde1793788e59121f34b5b7e.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606693,
+  "timestamp": 1757530492347,
   "ttl": 86400000,
   "query": "fuzzy_born in Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/254d0e2199fb02dbe5b865d84165ca23.json
+++ b/data/wikidata-cache/254d0e2199fb02dbe5b865d84165ca23.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609534,
+  "timestamp": 1757530494043,
   "ttl": 86400000,
   "query": "fuzzy_discovered the",
   "languages": "en",

--- a/data/wikidata-cache/26606ce878a877fae8706e149b934230.json
+++ b/data/wikidata-cache/26606ce878a877fae8706e149b934230.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616917,
+  "timestamp": 1757530498462,
   "ttl": 86400000,
   "query": "fuzzy_became",
   "languages": "en",

--- a/data/wikidata-cache/274047d99d716f8bfd373b0f507b406b.json
+++ b/data/wikidata-cache/274047d99d716f8bfd373b0f507b406b.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609528,
+  "timestamp": 1757530494076,
   "ttl": 86400000,
   "query": "fuzzy_Albert Einstein discovered",
   "languages": "en",

--- a/data/wikidata-cache/2772156316b0d6ecefd5acd58abf4ce8.json
+++ b/data/wikidata-cache/2772156316b0d6ecefd5acd58abf4ce8.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616241,
+  "timestamp": 1757530498023,
   "ttl": 86400000,
   "query": "and became the",
   "languages": "en",

--- a/data/wikidata-cache/298dc82917e4cf6c6c1f479d07aea230.json
+++ b/data/wikidata-cache/298dc82917e4cf6c6c1f479d07aea230.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634611060,
+  "timestamp": 1757530495011,
   "ttl": 86400000,
   "query": "fuzzy_is the capital",
   "languages": "en",

--- a/data/wikidata-cache/298dd55efb0535972c176765793f479a.json
+++ b/data/wikidata-cache/298dd55efb0535972c176765793f479a.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617661,
+  "timestamp": 1757530499248,
   "ttl": 86400000,
   "query": "Shakespeare wrote Romeo",
   "languages": "en",

--- a/data/wikidata-cache/299be14ac25d1762aa7e8febebd9d065.json
+++ b/data/wikidata-cache/299be14ac25d1762aa7e8febebd9d065.json
@@ -133,10 +133,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608824,
+  "timestamp": 1757530493592,
   "ttl": 86400000,
   "query": "fuzzy_White",
   "languages": "en",

--- a/data/wikidata-cache/2a895c30116a057bf38b46f331aeb6c1.json
+++ b/data/wikidata-cache/2a895c30116a057bf38b46f331aeb6c1.json
@@ -131,10 +131,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634614811,
+  "timestamp": 1757530497141,
   "ttl": 86400000,
   "query": "United Nations Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/2e83b7c934f0ad3de3dbc912f5c80992.json
+++ b/data/wikidata-cache/2e83b7c934f0ad3de3dbc912f5c80992.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494781,
   "ttl": 86400000,
   "query": "Paris is the",
   "languages": "en",

--- a/data/wikidata-cache/2ff7e6f9491cbba0d201f9abd711d53a.json
+++ b/data/wikidata-cache/2ff7e6f9491cbba0d201f9abd711d53a.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634614788,
+  "timestamp": 1757530497140,
   "ttl": 86400000,
   "query": "Nations Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/308e69a3e5ce60792319db6d8e1118c0.json
+++ b/data/wikidata-cache/308e69a3e5ce60792319db6d8e1118c0.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634616879,
+  "timestamp": 1757530498457,
   "ttl": 86400000,
   "query": "fuzzy_of the United",
   "languages": "en",

--- a/data/wikidata-cache/30957328e46ad89df934531ff7cb3097.json
+++ b/data/wikidata-cache/30957328e46ad89df934531ff7cb3097.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634607790,
+  "timestamp": 1757530492898,
   "ttl": 86400000,
   "query": "Obama visited",
   "languages": "en",

--- a/data/wikidata-cache/334b287275a879e3b4e8f51355cf5f79.json
+++ b/data/wikidata-cache/334b287275a879e3b4e8f51355cf5f79.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634611109,
+  "timestamp": 1757530495038,
   "ttl": 86400000,
   "query": "fuzzy_the capital of",
   "languages": "en",

--- a/data/wikidata-cache/339fbaffd81baee400f907d001d88f05.json
+++ b/data/wikidata-cache/339fbaffd81baee400f907d001d88f05.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P569",
         "title": "Property:P569",
@@ -150,7 +150,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753619293823,
+  "timestamp": 1757530492247,
   "ttl": 86400000,
   "query": "fuzzy_born",
   "languages": "en",

--- a/data/wikidata-cache/34559487ab168e6cc03eb6a9848201fe.json
+++ b/data/wikidata-cache/34559487ab168e6cc03eb6a9848201fe.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634614134,
+  "timestamp": 1757530496277,
   "ttl": 86400000,
   "query": "fuzzy_of America",
   "languages": "en",

--- a/data/wikidata-cache/3474e6ad8793fc6e203e6b96ef4b053a.json
+++ b/data/wikidata-cache/3474e6ad8793fc6e203e6b96ef4b053a.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634615449,
+  "timestamp": 1757530497413,
   "ttl": 86400000,
   "query": "fuzzy_Nations",
   "languages": "en",

--- a/data/wikidata-cache/35a6ab50210259cccb72a3356b3e7b9a.json
+++ b/data/wikidata-cache/35a6ab50210259cccb72a3356b3e7b9a.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P279",
         "title": "Property:P279",
@@ -150,7 +150,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634611080,
+  "timestamp": 1757530495067,
   "ttl": 86400000,
   "query": "fuzzy_is the",
   "languages": "en",

--- a/data/wikidata-cache/35f0f429e08993b15b926e8907995532.json
+++ b/data/wikidata-cache/35f0f429e08993b15b926e8907995532.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612491,
+  "timestamp": 1757530495841,
   "ttl": 86400000,
   "query": "States of America",
   "languages": "en",

--- a/data/wikidata-cache/37709e8d76bb1a4d6f8d4e236aa4b99c.json
+++ b/data/wikidata-cache/37709e8d76bb1a4d6f8d4e236aa4b99c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616888,
+  "timestamp": 1757530498420,
   "ttl": 86400000,
   "query": "fuzzy_in Hawaii and",
   "languages": "en",

--- a/data/wikidata-cache/37900ad9897dceb036f029bbcfa6b0c1.json
+++ b/data/wikidata-cache/37900ad9897dceb036f029bbcfa6b0c1.json
@@ -52,10 +52,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 2
   },
-  "timestamp": 1753634606686,
+  "timestamp": 1757530492202,
   "ttl": 86400000,
   "query": "in Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/3792c7a188b60f66db99b82060610814.json
+++ b/data/wikidata-cache/3792c7a188b60f66db99b82060610814.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P577",
         "title": "Property:P577",
@@ -141,7 +141,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634606727,
+  "timestamp": 1757530492337,
   "ttl": 86400000,
   "query": "fuzzy_was",
   "languages": "en",

--- a/data/wikidata-cache/38586ad91e4d7f6d330d606f15de846e.json
+++ b/data/wikidata-cache/38586ad91e4d7f6d330d606f15de846e.json
@@ -136,7 +136,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P35",
         "title": "Property:P35",
@@ -169,7 +169,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634612541,
+  "timestamp": 1757530495914,
   "ttl": 86400000,
   "query": "States",
   "languages": "en",

--- a/data/wikidata-cache/390db9cf7b37dafe0ffedd53bc5d0787.json
+++ b/data/wikidata-cache/390db9cf7b37dafe0ffedd53bc5d0787.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609202,
+  "timestamp": 1757530493794,
   "ttl": 86400000,
   "query": "Albert Einstein discovered",
   "languages": "en",

--- a/data/wikidata-cache/39894ab88bef1f1d4412c6697b9bdbf3.json
+++ b/data/wikidata-cache/39894ab88bef1f1d4412c6697b9bdbf3.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609514,
+  "timestamp": 1757530494103,
   "ttl": 86400000,
   "query": "of relativity",
   "languages": "en",

--- a/data/wikidata-cache/3999e6a383c126e55e04738a3faf624b.json
+++ b/data/wikidata-cache/3999e6a383c126e55e04738a3faf624b.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P53",
         "title": "Property:P53",
@@ -273,7 +273,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634608877,
+  "timestamp": 1757530493588,
   "ttl": 86400000,
   "query": "fuzzy_House",
   "languages": "en",

--- a/data/wikidata-cache/3b509806c1ea3f95ed9d6af8b3f554d5.json
+++ b/data/wikidata-cache/3b509806c1ea3f95ed9d6af8b3f554d5.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610251,
+  "timestamp": 1757530494451,
   "ttl": 86400000,
   "query": "fuzzy_Albert Einstein",
   "languages": "en",

--- a/data/wikidata-cache/3c566b10f08efa5aa561f703ed32c5d8.json
+++ b/data/wikidata-cache/3c566b10f08efa5aa561f703ed32c5d8.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606370,
+  "timestamp": 1757530492015,
   "ttl": 86400000,
   "query": "Barack Obama was",
   "languages": "en",

--- a/data/wikidata-cache/3df9cdae3fe331495550706614684525.json
+++ b/data/wikidata-cache/3df9cdae3fe331495550706614684525.json
@@ -52,10 +52,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 2
   },
-  "timestamp": 1753634607329,
+  "timestamp": 1757530492683,
   "ttl": 86400000,
   "query": "fuzzy_in Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/4046f2ed7388316203e05406b483a660.json
+++ b/data/wikidata-cache/4046f2ed7388316203e05406b483a660.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634619379,
+  "timestamp": 1757530500678,
   "ttl": 86400000,
   "query": "fuzzy_discovered relativity",
   "languages": "en",

--- a/data/wikidata-cache/44e2c43810c7bfebbcfd5dcdfe8fadd1.json
+++ b/data/wikidata-cache/44e2c43810c7bfebbcfd5dcdfe8fadd1.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634617308,
+  "timestamp": 1757530498459,
   "ttl": 86400000,
   "query": "fuzzy_President of",
   "languages": "en",

--- a/data/wikidata-cache/468f9913156fcfd727110a194f7b7287.json
+++ b/data/wikidata-cache/468f9913156fcfd727110a194f7b7287.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634608122,
+  "timestamp": 1757530493179,
   "ttl": 86400000,
   "query": "fuzzy_Barack Obama visited",
   "languages": "en",

--- a/data/wikidata-cache/4749f6b94478d50530e6a13c5e526a60.json
+++ b/data/wikidata-cache/4749f6b94478d50530e6a13c5e526a60.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616884,
+  "timestamp": 1757530498388,
   "ttl": 86400000,
   "query": "fuzzy_Hawaii and became",
   "languages": "en",

--- a/data/wikidata-cache/4b101fc4661a1566ce91b86e0b7ca242.json
+++ b/data/wikidata-cache/4b101fc4661a1566ce91b86e0b7ca242.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609651,
+  "timestamp": 1757530494105,
   "ttl": 86400000,
   "query": "fuzzy_discovered the theory",
   "languages": "en",

--- a/data/wikidata-cache/4b1d73f870596757dbf3882140014064.json
+++ b/data/wikidata-cache/4b1d73f870596757dbf3882140014064.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606370,
+  "timestamp": 1757530491878,
   "ttl": 86400000,
   "query": "Obama was",
   "languages": "en",

--- a/data/wikidata-cache/4b4cb7af89999b79903c815db2bbccfc.json
+++ b/data/wikidata-cache/4b4cb7af89999b79903c815db2bbccfc.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6617",
         "title": "Property:P6617",
@@ -160,7 +160,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634618014,
+  "timestamp": 1757530499423,
   "ttl": 86400000,
   "query": "Romeo",
   "languages": "en",

--- a/data/wikidata-cache/4b959d77658b3a39b52088160f2ddda2.json
+++ b/data/wikidata-cache/4b959d77658b3a39b52088160f2ddda2.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608804,
+  "timestamp": 1757530493475,
   "ttl": 86400000,
   "query": "fuzzy_the White House",
   "languages": "en",

--- a/data/wikidata-cache/4de7df7904d99b209fbc72f46b6eb175.json
+++ b/data/wikidata-cache/4de7df7904d99b209fbc72f46b6eb175.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P569",
         "title": "Property:P569",
@@ -150,7 +150,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753619292247,
+  "timestamp": 1757530491874,
   "ttl": 86400000,
   "query": "born",
   "languages": "en",

--- a/data/wikidata-cache/4e32e293b4b0952e78e725c36a79fe09.json
+++ b/data/wikidata-cache/4e32e293b4b0952e78e725c36a79fe09.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634616244,
+  "timestamp": 1757530498091,
   "ttl": 86400000,
   "query": "of the United",
   "languages": "en",

--- a/data/wikidata-cache/4e6ccb7396e6457189601d8fe970d190.json
+++ b/data/wikidata-cache/4e6ccb7396e6457189601d8fe970d190.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613289,
+  "timestamp": 1757530496325,
   "ttl": 86400000,
   "query": "fuzzy_of America president Barack",
   "languages": "en",

--- a/data/wikidata-cache/5062e2f196f36876ca792fbb70435c05.json
+++ b/data/wikidata-cache/5062e2f196f36876ca792fbb70435c05.json
@@ -92,12 +92,12 @@
             "language": "en"
           },
           "description": {
-            "value": "American automotive manufacturing corporation",
+            "value": "American multinational automotive company",
             "language": "en"
           }
         },
         "label": "General Motors",
-        "description": "American automotive manufacturing corporation",
+        "description": "American multinational automotive company",
         "match": {
           "type": "label",
           "language": "en",
@@ -133,7 +133,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P8795",
         "title": "Property:P8795",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634614890,
+  "timestamp": 1757530497084,
   "ttl": 86400000,
   "query": "General",
   "languages": "en",

--- a/data/wikidata-cache/56cbeac00c56c19cd6cfdfb3f134bdbc.json
+++ b/data/wikidata-cache/56cbeac00c56c19cd6cfdfb3f134bdbc.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P800",
         "title": "Property:P800",
@@ -92,7 +92,7 @@
     ],
     "total": 3
   },
-  "timestamp": 1753634617692,
+  "timestamp": 1757530499223,
   "ttl": 86400000,
   "query": "wrote",
   "languages": "en",

--- a/data/wikidata-cache/5a35d1e72165a69b7493e721148384c8.json
+++ b/data/wikidata-cache/5a35d1e72165a69b7493e721148384c8.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606379,
+  "timestamp": 1757530492000,
   "ttl": 86400000,
   "query": "Obama was born",
   "languages": "en",

--- a/data/wikidata-cache/5b669c5757dcd08bb81e42b742f824a2.json
+++ b/data/wikidata-cache/5b669c5757dcd08bb81e42b742f824a2.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634608111,
+  "timestamp": 1757530493105,
   "ttl": 86400000,
   "query": "fuzzy_visited the White",
   "languages": "en",

--- a/data/wikidata-cache/5c8aac806b5aa9f6e0acc4b14b6ee42e.json
+++ b/data/wikidata-cache/5c8aac806b5aa9f6e0acc4b14b6ee42e.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616875,
+  "timestamp": 1757530498441,
   "ttl": 86400000,
   "query": "fuzzy_and became",
   "languages": "en",

--- a/data/wikidata-cache/5cfbc6d8c019187bd7d0a2afe001f224.json
+++ b/data/wikidata-cache/5cfbc6d8c019187bd7d0a2afe001f224.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P1376",
         "title": "Property:P1376",
@@ -31,7 +31,7 @@
     ],
     "total": 1
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494886,
   "ttl": 86400000,
   "query": "capital of",
   "languages": "en",

--- a/data/wikidata-cache/5d6cfe97444f098e1c77ccbb0f914ccb.json
+++ b/data/wikidata-cache/5d6cfe97444f098e1c77ccbb0f914ccb.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634608116,
+  "timestamp": 1757530493139,
   "ttl": 86400000,
   "query": "fuzzy_Obama visited the",
   "languages": "en",

--- a/data/wikidata-cache/5ee3f577275949146be0d3194850fb1b.json
+++ b/data/wikidata-cache/5ee3f577275949146be0d3194850fb1b.json
@@ -139,10 +139,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634617053,
+  "timestamp": 1757530498534,
   "ttl": 86400000,
   "query": "fuzzy_President of the",
   "languages": "en",

--- a/data/wikidata-cache/5f002255e715425e8afa761c0715f7c8.json
+++ b/data/wikidata-cache/5f002255e715425e8afa761c0715f7c8.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616236,
+  "timestamp": 1757530498071,
   "ttl": 86400000,
   "query": "and became",
   "languages": "en",

--- a/data/wikidata-cache/5f135b14d4f057b1131e799e79b9e2a3.json
+++ b/data/wikidata-cache/5f135b14d4f057b1131e799e79b9e2a3.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753619282141,
+  "timestamp": 1757530499363,
   "ttl": 86400000,
   "query": "fuzzy_Shakespeare",
   "languages": "en",

--- a/data/wikidata-cache/5fce509be079e1c1d4fa9f0fa80f51ae.json
+++ b/data/wikidata-cache/5fce509be079e1c1d4fa9f0fa80f51ae.json
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634611060,
+  "timestamp": 1757530494998,
   "ttl": 86400000,
   "query": "the capital",
   "languages": "en",

--- a/data/wikidata-cache/600b5efa345394e882426d487ebba677.json
+++ b/data/wikidata-cache/600b5efa345394e882426d487ebba677.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617668,
+  "timestamp": 1757530499258,
   "ttl": 86400000,
   "query": "wrote Romeo",
   "languages": "en",

--- a/data/wikidata-cache/62f109d0b8495f1586b41e35da5b8183.json
+++ b/data/wikidata-cache/62f109d0b8495f1586b41e35da5b8183.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P279",
         "title": "Property:P279",
@@ -150,7 +150,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494837,
   "ttl": 86400000,
   "query": "is the",
   "languages": "en",

--- a/data/wikidata-cache/63b0d8a59a85841f068838642282cf97.json
+++ b/data/wikidata-cache/63b0d8a59a85841f068838642282cf97.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -21,10 +21,13 @@
         "label": "Barack Obama",
         "description": "president of the United States from 2009 to 2017",
         "match": {
-          "type": "label",
+          "type": "alias",
           "language": "en",
-          "text": "Barack Obama"
-        }
+          "text": "Barack"
+        },
+        "aliases": [
+          "Barack"
+        ]
       },
       {
         "id": "Q18643532",
@@ -127,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619262525,
+  "timestamp": 1757530492099,
   "ttl": 86400000,
   "query": "Barack",
   "languages": "en",

--- a/data/wikidata-cache/647de48c69c3a8eb8e206a82cce72bd9.json
+++ b/data/wikidata-cache/647de48c69c3a8eb8e206a82cce72bd9.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6",
         "title": "Property:P6",
@@ -279,7 +279,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634617004,
+  "timestamp": 1757530498957,
   "ttl": 86400000,
   "query": "fuzzy_President",
   "languages": "en",

--- a/data/wikidata-cache/64dc451f4b8ad1b67329cd73a1bc545c.json
+++ b/data/wikidata-cache/64dc451f4b8ad1b67329cd73a1bc545c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610743,
+  "timestamp": 1757530494800,
   "ttl": 86400000,
   "query": "is the capital",
   "languages": "en",

--- a/data/wikidata-cache/651c3c682637593481d4a22788dbc170.json
+++ b/data/wikidata-cache/651c3c682637593481d4a22788dbc170.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -120,10 +120,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634613132,
+  "timestamp": 1757530496394,
   "ttl": 86400000,
   "query": "fuzzy_president Barack",
   "languages": "en",

--- a/data/wikidata-cache/664850ab6422e67b614faa0735adb5fd.json
+++ b/data/wikidata-cache/664850ab6422e67b614faa0735adb5fd.json
@@ -105,32 +105,32 @@
         ]
       },
       {
-        "id": "Q33569",
-        "title": "Q33569",
-        "pageid": 36405,
-        "concepturi": "http://www.wikidata.org/entity/Q33569",
+        "id": "Q697407",
+        "title": "Q697407",
+        "pageid": 656723,
+        "concepturi": "http://www.wikidata.org/entity/Q697407",
         "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q33569",
+        "url": "//www.wikidata.org/wiki/Q697407",
         "display": {
           "label": {
-            "value": "Hawaiian",
+            "value": "Hawaii Five-O",
             "language": "en"
           },
           "description": {
-            "value": "Polynesian language",
+            "value": "1968 American TV series",
             "language": "en"
           }
         },
-        "label": "Hawaiian",
-        "description": "Polynesian language",
+        "label": "Hawaii Five-O",
+        "description": "1968 American TV series",
         "match": {
           "type": "label",
           "language": "en",
-          "text": "Hawaiian"
+          "text": "Hawaii Five-O"
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P4365",
         "title": "Property:P4365",
@@ -163,7 +163,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634607467,
+  "timestamp": 1757530492626,
   "ttl": 86400000,
   "query": "fuzzy_Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/667226be400ae5ba1e2dc5832b2d950d.json
+++ b/data/wikidata-cache/667226be400ae5ba1e2dc5832b2d950d.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612646,
+  "timestamp": 1757530495925,
   "ttl": 86400000,
   "query": "of America president Barack",
   "languages": "en",

--- a/data/wikidata-cache/669b2bdaa3ea1c4f5473e3857a00d14a.json
+++ b/data/wikidata-cache/669b2bdaa3ea1c4f5473e3857a00d14a.json
@@ -131,10 +131,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634614792,
+  "timestamp": 1757530497011,
   "ttl": 86400000,
   "query": "United Nations Secretary",
   "languages": "en",

--- a/data/wikidata-cache/68389fb652aae193dd7b9d01d1edb5fb.json
+++ b/data/wikidata-cache/68389fb652aae193dd7b9d01d1edb5fb.json
@@ -30,10 +30,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634611734,
+  "timestamp": 1757530495436,
   "ttl": 86400000,
   "query": "fuzzy_of France",
   "languages": "en",

--- a/data/wikidata-cache/69abf7f11394c99c08096027c8a05425.json
+++ b/data/wikidata-cache/69abf7f11394c99c08096027c8a05425.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613369,
+  "timestamp": 1757530496218,
   "ttl": 86400000,
   "query": "fuzzy_States of America president",
   "languages": "en",

--- a/data/wikidata-cache/69ec05e8757f2bf6f98de2c070eedb70.json
+++ b/data/wikidata-cache/69ec05e8757f2bf6f98de2c070eedb70.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606679,
+  "timestamp": 1757530492224,
   "ttl": 86400000,
   "query": "fuzzy_Obama was",
   "languages": "en",

--- a/data/wikidata-cache/6b3b1fcda63307cfdc3b38e06ed07386.json
+++ b/data/wikidata-cache/6b3b1fcda63307cfdc3b38e06ed07386.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634607803,
+  "timestamp": 1757530492887,
   "ttl": 86400000,
   "query": "Barack Obama visited",
   "languages": "en",

--- a/data/wikidata-cache/6bccd864c5b427bc68b1b4a382b19c81.json
+++ b/data/wikidata-cache/6bccd864c5b427bc68b1b4a382b19c81.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -120,10 +120,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634612513,
+  "timestamp": 1757530495942,
   "ttl": 86400000,
   "query": "president Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/6c3a3b281d480240621d12f375562b58.json
+++ b/data/wikidata-cache/6c3a3b281d480240621d12f375562b58.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616250,
+  "timestamp": 1757530498013,
   "ttl": 86400000,
   "query": "in Hawaii and",
   "languages": "en",

--- a/data/wikidata-cache/6c7e8bb6d36dce247a580b82f2d421a0.json
+++ b/data/wikidata-cache/6c7e8bb6d36dce247a580b82f2d421a0.json
@@ -117,10 +117,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610228,
+  "timestamp": 1757530494582,
   "ttl": 86400000,
   "query": "fuzzy_the theory",
   "languages": "en",

--- a/data/wikidata-cache/6d53fe494fd51eb91edb67fb2a1718f1.json
+++ b/data/wikidata-cache/6d53fe494fd51eb91edb67fb2a1718f1.json
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634611721,
+  "timestamp": 1757530495442,
   "ttl": 86400000,
   "query": "fuzzy_the capital",
   "languages": "en",

--- a/data/wikidata-cache/6de112f4920003794e893148827a445a.json
+++ b/data/wikidata-cache/6de112f4920003794e893148827a445a.json
@@ -127,7 +127,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P8795",
         "title": "Property:P8795",
@@ -212,7 +212,7 @@
     ],
     "total": 8
   },
-  "timestamp": 1753634610288,
+  "timestamp": 1757530494525,
   "ttl": 86400000,
   "query": "fuzzy_Albert",
   "languages": "en",

--- a/data/wikidata-cache/6ee27b2695f8eda5b83d1c7efff16eac.json
+++ b/data/wikidata-cache/6ee27b2695f8eda5b83d1c7efff16eac.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606692,
+  "timestamp": 1757530492327,
   "ttl": 86400000,
   "query": "fuzzy_Barack Obama was",
   "languages": "en",

--- a/data/wikidata-cache/6efa8daa6ca1170665d69deba12a87cd.json
+++ b/data/wikidata-cache/6efa8daa6ca1170665d69deba12a87cd.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609333,
+  "timestamp": 1757530493809,
   "ttl": 86400000,
   "query": "discovered the theory",
   "languages": "en",

--- a/data/wikidata-cache/6fc0944e53346318cbf0e53aa37a68de.json
+++ b/data/wikidata-cache/6fc0944e53346318cbf0e53aa37a68de.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634611102,
+  "timestamp": 1757530495001,
   "ttl": 86400000,
   "query": "fuzzy_capital of France",
   "languages": "en",

--- a/data/wikidata-cache/6fc6fd45df23202267dc0941cc9c8919.json
+++ b/data/wikidata-cache/6fc6fd45df23202267dc0941cc9c8919.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634613228,
+  "timestamp": 1757530496245,
   "ttl": 86400000,
   "query": "fuzzy_States of",
   "languages": "en",

--- a/data/wikidata-cache/70134751a2316042b394db49e33ec624.json
+++ b/data/wikidata-cache/70134751a2316042b394db49e33ec624.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606367,
+  "timestamp": 1757530492007,
   "ttl": 86400000,
   "query": "was born in",
   "languages": "en",

--- a/data/wikidata-cache/712329ae72981b00e639f54ff5f40a21.json
+++ b/data/wikidata-cache/712329ae72981b00e639f54ff5f40a21.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634617988,
+  "timestamp": 1757530499425,
   "ttl": 86400000,
   "query": "Romeo and",
   "languages": "en",

--- a/data/wikidata-cache/719da1cf3813d800b7d8c5ff8c646d01.json
+++ b/data/wikidata-cache/719da1cf3813d800b7d8c5ff8c646d01.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608146,
+  "timestamp": 1757530493108,
   "ttl": 86400000,
   "query": "the White House",
   "languages": "en",

--- a/data/wikidata-cache/71d1c1dd35bef6d33e04e75730a3020d.json
+++ b/data/wikidata-cache/71d1c1dd35bef6d33e04e75730a3020d.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634618731,
+  "timestamp": 1757530499965,
   "ttl": 86400000,
   "query": "fuzzy_Romeo and",
   "languages": "en",

--- a/data/wikidata-cache/72d607129777189c9790075c15a9dc8c.json
+++ b/data/wikidata-cache/72d607129777189c9790075c15a9dc8c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494817,
   "ttl": 86400000,
   "query": "capital of France",
   "languages": "en",

--- a/data/wikidata-cache/730d903bbd0d419314c717617c3c2974.json
+++ b/data/wikidata-cache/730d903bbd0d419314c717617c3c2974.json
@@ -112,10 +112,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609698,
+  "timestamp": 1757530494104,
   "ttl": 86400000,
   "query": "the theory of",
   "languages": "en",

--- a/data/wikidata-cache/7335f009f3cd390365825b2fa75fc83d.json
+++ b/data/wikidata-cache/7335f009f3cd390365825b2fa75fc83d.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619272348,
+  "timestamp": 1757530493979,
   "ttl": 86400000,
   "query": "Einstein",
   "languages": "en",

--- a/data/wikidata-cache/7349eea3a45032273ddd41096eb0aacd.json
+++ b/data/wikidata-cache/7349eea3a45032273ddd41096eb0aacd.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616267,
+  "timestamp": 1757530498137,
   "ttl": 86400000,
   "query": "became the President",
   "languages": "en",

--- a/data/wikidata-cache/73e7ebee743f5ead84daf6d897b1f675.json
+++ b/data/wikidata-cache/73e7ebee743f5ead84daf6d897b1f675.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616939,
+  "timestamp": 1757530498527,
   "ttl": 86400000,
   "query": "fuzzy_the United",
   "languages": "en",

--- a/data/wikidata-cache/74f5d797ddb720fa0c1fb135b119cea6.json
+++ b/data/wikidata-cache/74f5d797ddb720fa0c1fb135b119cea6.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6",
         "title": "Property:P6",
@@ -279,7 +279,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634612542,
+  "timestamp": 1757530495918,
   "ttl": 86400000,
   "query": "president",
   "languages": "en",

--- a/data/wikidata-cache/7637bbddfcd5a16c75d99f6ba0aa69c2.json
+++ b/data/wikidata-cache/7637bbddfcd5a16c75d99f6ba0aa69c2.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606701,
+  "timestamp": 1757530492295,
   "ttl": 86400000,
   "query": "fuzzy_was born in",
   "languages": "en",

--- a/data/wikidata-cache/76b989b246d588a05d7bbb146e5ae19b.json
+++ b/data/wikidata-cache/76b989b246d588a05d7bbb146e5ae19b.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634614811,
+  "timestamp": 1757530497034,
   "ttl": 86400000,
   "query": "Nations",
   "languages": "en",

--- a/data/wikidata-cache/78a3f709334c66a12af04a0c907b22b0.json
+++ b/data/wikidata-cache/78a3f709334c66a12af04a0c907b22b0.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613110,
+  "timestamp": 1757530496324,
   "ttl": 86400000,
   "query": "fuzzy_America president",
   "languages": "en",

--- a/data/wikidata-cache/7917f05a3f61594cff66f184d0395bdb.json
+++ b/data/wikidata-cache/7917f05a3f61594cff66f184d0395bdb.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6347",
         "title": "Property:P6347",
@@ -163,7 +163,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634608158,
+  "timestamp": 1757530493116,
   "ttl": 86400000,
   "query": "the White",
   "languages": "en",

--- a/data/wikidata-cache/7c0b9313304fa23882df275e5228f55d.json
+++ b/data/wikidata-cache/7c0b9313304fa23882df275e5228f55d.json
@@ -136,10 +136,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609553,
+  "timestamp": 1757530494024,
   "ttl": 86400000,
   "query": "theory",
   "languages": "en",

--- a/data/wikidata-cache/7e106aa25627fae6f732bca5cee983e3.json
+++ b/data/wikidata-cache/7e106aa25627fae6f732bca5cee983e3.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634612558,
+  "timestamp": 1757530495855,
   "ttl": 86400000,
   "query": "States of",
   "languages": "en",

--- a/data/wikidata-cache/7e4d93233a7fc7deff6a22eb4c11c61c.json
+++ b/data/wikidata-cache/7e4d93233a7fc7deff6a22eb4c11c61c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612504,
+  "timestamp": 1757530495898,
   "ttl": 86400000,
   "query": "of America president",
   "languages": "en",

--- a/data/wikidata-cache/7feea328144475205d817dd1aa897c9b.json
+++ b/data/wikidata-cache/7feea328144475205d817dd1aa897c9b.json
@@ -130,7 +130,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1225",
         "title": "Property:P1225",
@@ -199,7 +199,7 @@
         "url": "//www.wikidata.org/wiki/Property:P7063",
         "display": {
           "label": {
-            "value": "U. S. Supreme Court docket number",
+            "value": "U.S. Supreme Court docket number",
             "language": "en"
           },
           "description": {
@@ -207,7 +207,7 @@
             "language": "en"
           }
         },
-        "label": "U. S. Supreme Court docket number",
+        "label": "U.S. Supreme Court docket number",
         "description": "identifier for a case filed at the Supreme Court of the United States",
         "match": {
           "type": "alias",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634613260,
+  "timestamp": 1757530496411,
   "ttl": 86400000,
   "query": "fuzzy_United States",
   "languages": "en",

--- a/data/wikidata-cache/80418c53897412a63fd013719eec53ee.json
+++ b/data/wikidata-cache/80418c53897412a63fd013719eec53ee.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -120,10 +120,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634612500,
+  "timestamp": 1757530495900,
   "ttl": 86400000,
   "query": "president Barack",
   "languages": "en",

--- a/data/wikidata-cache/825a4748e84d55b0d2612dcef37f67c6.json
+++ b/data/wikidata-cache/825a4748e84d55b0d2612dcef37f67c6.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616289,
+  "timestamp": 1757530498137,
   "ttl": 86400000,
   "query": "the United States",
   "languages": "en",

--- a/data/wikidata-cache/84d392118cea893786ab6bb73171ec27.json
+++ b/data/wikidata-cache/84d392118cea893786ab6bb73171ec27.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613335,
+  "timestamp": 1757530496379,
   "ttl": 86400000,
   "query": "fuzzy_America president Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/854acb0c45eac835bb935828c5180c39.json
+++ b/data/wikidata-cache/854acb0c45eac835bb935828c5180c39.json
@@ -117,10 +117,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609553,
+  "timestamp": 1757530494104,
   "ttl": 86400000,
   "query": "the theory",
   "languages": "en",

--- a/data/wikidata-cache/87bcd36e10df0319361dec4794a8303d.json
+++ b/data/wikidata-cache/87bcd36e10df0319361dec4794a8303d.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753619281818,
+  "timestamp": 1757530499200,
   "ttl": 86400000,
   "query": "Shakespeare",
   "languages": "en",

--- a/data/wikidata-cache/87e61d8f263d34a992bcb712374b98f0.json
+++ b/data/wikidata-cache/87e61d8f263d34a992bcb712374b98f0.json
@@ -27,6 +27,34 @@
         }
       },
       {
+        "id": "Q740308",
+        "title": "Q740308",
+        "pageid": 696340,
+        "concepturi": "http://www.wikidata.org/entity/Q740308",
+        "repository": "wikidata",
+        "url": "//www.wikidata.org/wiki/Q740308",
+        "display": {
+          "label": {
+            "value": "UNICEF",
+            "language": "en"
+          },
+          "description": {
+            "value": "fund of United Nations",
+            "language": "en"
+          }
+        },
+        "label": "UNICEF",
+        "description": "fund of United Nations",
+        "match": {
+          "type": "alias",
+          "language": "en",
+          "text": "United Nations Children's Fund"
+        },
+        "aliases": [
+          "United Nations Children's Fund"
+        ]
+      },
+      {
         "id": "Q9259",
         "title": "Q9259",
         "pageid": 10620,
@@ -103,37 +131,9 @@
           "language": "en",
           "text": "United Nations Security Council resolution"
         }
-      },
-      {
-        "id": "Q7809",
-        "title": "Q7809",
-        "pageid": 9055,
-        "concepturi": "http://www.wikidata.org/entity/Q7809",
-        "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q7809",
-        "display": {
-          "label": {
-            "value": "UNESCO",
-            "language": "en"
-          },
-          "description": {
-            "value": "specialised agency of the United Nations for education, sciences, and culture",
-            "language": "en"
-          }
-        },
-        "label": "UNESCO",
-        "description": "specialised agency of the United Nations for education, sciences, and culture",
-        "match": {
-          "type": "alias",
-          "language": "en",
-          "text": "United Nations Educational, Scientific and Cultural Organization"
-        },
-        "aliases": [
-          "United Nations Educational, Scientific and Cultural Organization"
-        ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1937",
         "title": "Property:P1937",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634615506,
+  "timestamp": 1757530497637,
   "ttl": 86400000,
   "query": "fuzzy_United Nations",
   "languages": "en",

--- a/data/wikidata-cache/88c1d4dc55cbf531ea2cfcf01cba0d6e.json
+++ b/data/wikidata-cache/88c1d4dc55cbf531ea2cfcf01cba0d6e.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634608101,
+  "timestamp": 1757530493179,
   "ttl": 86400000,
   "query": "fuzzy_visited the",
   "languages": "en",

--- a/data/wikidata-cache/88dbd78b56cdc5d6e29a6f56603c8b64.json
+++ b/data/wikidata-cache/88dbd78b56cdc5d6e29a6f56603c8b64.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617974,
+  "timestamp": 1757530499982,
   "ttl": 86400000,
   "query": "fuzzy_Shakespeare wrote Romeo",
   "languages": "en",

--- a/data/wikidata-cache/8a88fd88a7ee06cf60fd4817dd0f2919.json
+++ b/data/wikidata-cache/8a88fd88a7ee06cf60fd4817dd0f2919.json
@@ -27,6 +27,34 @@
         }
       },
       {
+        "id": "Q740308",
+        "title": "Q740308",
+        "pageid": 696340,
+        "concepturi": "http://www.wikidata.org/entity/Q740308",
+        "repository": "wikidata",
+        "url": "//www.wikidata.org/wiki/Q740308",
+        "display": {
+          "label": {
+            "value": "UNICEF",
+            "language": "en"
+          },
+          "description": {
+            "value": "fund of United Nations",
+            "language": "en"
+          }
+        },
+        "label": "UNICEF",
+        "description": "fund of United Nations",
+        "match": {
+          "type": "alias",
+          "language": "en",
+          "text": "United Nations Children's Fund"
+        },
+        "aliases": [
+          "United Nations Children's Fund"
+        ]
+      },
+      {
         "id": "Q9259",
         "title": "Q9259",
         "pageid": 10620,
@@ -103,37 +131,9 @@
           "language": "en",
           "text": "United Nations Security Council resolution"
         }
-      },
-      {
-        "id": "Q7809",
-        "title": "Q7809",
-        "pageid": 9055,
-        "concepturi": "http://www.wikidata.org/entity/Q7809",
-        "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q7809",
-        "display": {
-          "label": {
-            "value": "UNESCO",
-            "language": "en"
-          },
-          "description": {
-            "value": "specialised agency of the United Nations for education, sciences, and culture",
-            "language": "en"
-          }
-        },
-        "label": "UNESCO",
-        "description": "specialised agency of the United Nations for education, sciences, and culture",
-        "match": {
-          "type": "alias",
-          "language": "en",
-          "text": "United Nations Educational, Scientific and Cultural Organization"
-        },
-        "aliases": [
-          "United Nations Educational, Scientific and Cultural Organization"
-        ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1937",
         "title": "Property:P1937",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634614841,
+  "timestamp": 1757530497093,
   "ttl": 86400000,
   "query": "United Nations",
   "languages": "en",

--- a/data/wikidata-cache/8b5a0164335b00c0efe2e30e5e016756.json
+++ b/data/wikidata-cache/8b5a0164335b00c0efe2e30e5e016756.json
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634612561,
+  "timestamp": 1757530495899,
   "ttl": 86400000,
   "query": "United States of America",
   "languages": "en",

--- a/data/wikidata-cache/8d36b4acefa58b63ecf27ab8d463b923.json
+++ b/data/wikidata-cache/8d36b4acefa58b63ecf27ab8d463b923.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612474,
+  "timestamp": 1757530495893,
   "ttl": 86400000,
   "query": "America president",
   "languages": "en",

--- a/data/wikidata-cache/8e1d1c8e35b600c1d1befdd78706f1b1.json
+++ b/data/wikidata-cache/8e1d1c8e35b600c1d1befdd78706f1b1.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616259,
+  "timestamp": 1757530498038,
   "ttl": 86400000,
   "query": "Hawaii and became",
   "languages": "en",

--- a/data/wikidata-cache/8f789c3d2eac7def7fdcdc6823a07dd0.json
+++ b/data/wikidata-cache/8f789c3d2eac7def7fdcdc6823a07dd0.json
@@ -77,10 +77,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 3
   },
-  "timestamp": 1753634616939,
+  "timestamp": 1757530498534,
   "ttl": 86400000,
   "query": "fuzzy_Hawaii and",
   "languages": "en",

--- a/data/wikidata-cache/90ff2db22c48f7eb4c50397729490559.json
+++ b/data/wikidata-cache/90ff2db22c48f7eb4c50397729490559.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612694,
+  "timestamp": 1757530495857,
   "ttl": 86400000,
   "query": "States of America president",
   "languages": "en",

--- a/data/wikidata-cache/91bf24d2dff78bce5075c532f120e268.json
+++ b/data/wikidata-cache/91bf24d2dff78bce5075c532f120e268.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -21,10 +21,13 @@
         "label": "Barack Obama",
         "description": "president of the United States from 2009 to 2017",
         "match": {
-          "type": "label",
+          "type": "alias",
           "language": "en",
-          "text": "Barack Obama"
-        }
+          "text": "Barack"
+        },
+        "aliases": [
+          "Barack"
+        ]
       },
       {
         "id": "Q18643532",
@@ -127,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619263722,
+  "timestamp": 1757530492577,
   "ttl": 86400000,
   "query": "fuzzy_Barack",
   "languages": "en",

--- a/data/wikidata-cache/94e839606c99686c606e026560dc08c4.json
+++ b/data/wikidata-cache/94e839606c99686c606e026560dc08c4.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617988,
+  "timestamp": 1757530499392,
   "ttl": 86400000,
   "query": "fuzzy_wrote Romeo and",
   "languages": "en",

--- a/data/wikidata-cache/95c2506eb112cea5b6ab047e2446d6bd.json
+++ b/data/wikidata-cache/95c2506eb112cea5b6ab047e2446d6bd.json
@@ -92,12 +92,12 @@
             "language": "en"
           },
           "description": {
-            "value": "American automotive manufacturing corporation",
+            "value": "American multinational automotive company",
             "language": "en"
           }
         },
         "label": "General Motors",
-        "description": "American automotive manufacturing corporation",
+        "description": "American multinational automotive company",
         "match": {
           "type": "label",
           "language": "en",
@@ -133,7 +133,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P8795",
         "title": "Property:P8795",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634615600,
+  "timestamp": 1757530497612,
   "ttl": 86400000,
   "query": "fuzzy_General",
   "languages": "en",

--- a/data/wikidata-cache/95d8a1b8b1aa29557327547a4d493be4.json
+++ b/data/wikidata-cache/95d8a1b8b1aa29557327547a4d493be4.json
@@ -127,7 +127,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P9371",
         "title": "Property:P9371",
@@ -264,7 +264,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634611129,
+  "timestamp": 1757530495033,
   "ttl": 86400000,
   "query": "France",
   "languages": "en",

--- a/data/wikidata-cache/97227ba9016335fcc13845f44f689790.json
+++ b/data/wikidata-cache/97227ba9016335fcc13845f44f689790.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606370,
+  "timestamp": 1757530492025,
   "ttl": 86400000,
   "query": "born in Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/97877ec51fe95469c1a011db926e7817.json
+++ b/data/wikidata-cache/97877ec51fe95469c1a011db926e7817.json
@@ -133,7 +133,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P4636",
         "title": "Property:P4636",
@@ -166,7 +166,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634618731,
+  "timestamp": 1757530499809,
   "ttl": 86400000,
   "query": "fuzzy_Juliet",
   "languages": "en",

--- a/data/wikidata-cache/98aca1e6c70f07d38bcb3b255714109c.json
+++ b/data/wikidata-cache/98aca1e6c70f07d38bcb3b255714109c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613144,
+  "timestamp": 1757530496213,
   "ttl": 86400000,
   "query": "fuzzy_States of America",
   "languages": "en",

--- a/data/wikidata-cache/98e87162d9bfd922a7bc797d82920007.json
+++ b/data/wikidata-cache/98e87162d9bfd922a7bc797d82920007.json
@@ -133,10 +133,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634613227,
+  "timestamp": 1757530496323,
   "ttl": 86400000,
   "query": "fuzzy_United States of America",
   "languages": "en",

--- a/data/wikidata-cache/9957cecc8686abd9b27e5dcb91d24ef6.json
+++ b/data/wikidata-cache/9957cecc8686abd9b27e5dcb91d24ef6.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616968,
+  "timestamp": 1757530498469,
   "ttl": 86400000,
   "query": "fuzzy_the President",
   "languages": "en",

--- a/data/wikidata-cache/99e7609e65da4c047ba82e11379b9c1d.json
+++ b/data/wikidata-cache/99e7609e65da4c047ba82e11379b9c1d.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609211,
+  "timestamp": 1757530493788,
   "ttl": 86400000,
   "query": "discovered the",
   "languages": "en",

--- a/data/wikidata-cache/9a8a08c300f0b6a66d05383147f75e0e.json
+++ b/data/wikidata-cache/9a8a08c300f0b6a66d05383147f75e0e.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P1376",
         "title": "Property:P1376",
@@ -31,7 +31,7 @@
     ],
     "total": 1
   },
-  "timestamp": 1753634611111,
+  "timestamp": 1757530495082,
   "ttl": 86400000,
   "query": "fuzzy_capital of",
   "languages": "en",

--- a/data/wikidata-cache/9d4eb5df56ffc375d56dae469bfa48dd.json
+++ b/data/wikidata-cache/9d4eb5df56ffc375d56dae469bfa48dd.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606689,
+  "timestamp": 1757530492279,
   "ttl": 86400000,
   "query": "fuzzy_was born",
   "languages": "en",

--- a/data/wikidata-cache/9d62844d6bb6769a55e9e27172ae3097.json
+++ b/data/wikidata-cache/9d62844d6bb6769a55e9e27172ae3097.json
@@ -136,10 +136,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610237,
+  "timestamp": 1757530494452,
   "ttl": 86400000,
   "query": "fuzzy_theory",
   "languages": "en",

--- a/data/wikidata-cache/9f93078a049ebcaa344db05a71758c0d.json
+++ b/data/wikidata-cache/9f93078a049ebcaa344db05a71758c0d.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616257,
+  "timestamp": 1757530498071,
   "ttl": 86400000,
   "query": "became",
   "languages": "en",

--- a/data/wikidata-cache/9f99c046d43049a10a4ebe6b67d5d93c.json
+++ b/data/wikidata-cache/9f99c046d43049a10a4ebe6b67d5d93c.json
@@ -128,10 +128,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616659,
+  "timestamp": 1757530498055,
   "ttl": 86400000,
   "query": "the President of",
   "languages": "en",

--- a/data/wikidata-cache/a018baf8643e904ba1b86003d7a1df47.json
+++ b/data/wikidata-cache/a018baf8643e904ba1b86003d7a1df47.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P19",
         "title": "Property:P19",
@@ -34,7 +34,7 @@
     ],
     "total": 1
   },
-  "timestamp": 1753634606392,
+  "timestamp": 1757530492013,
   "ttl": 86400000,
   "query": "born in",
   "languages": "en",

--- a/data/wikidata-cache/a340826e76b520eeb6aab83bb21f33ca.json
+++ b/data/wikidata-cache/a340826e76b520eeb6aab83bb21f33ca.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P577",
         "title": "Property:P577",
@@ -141,7 +141,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634606378,
+  "timestamp": 1757530491963,
   "ttl": 86400000,
   "query": "was",
   "languages": "en",

--- a/data/wikidata-cache/a3e2349d6bb1e47a40eda2a128ba0f60.json
+++ b/data/wikidata-cache/a3e2349d6bb1e47a40eda2a128ba0f60.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P213",
         "title": "Property:P213",
@@ -138,7 +138,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634611083,
+  "timestamp": 1757530495050,
   "ttl": 86400000,
   "query": "fuzzy_is",
   "languages": "en",

--- a/data/wikidata-cache/a5a4a89ae163cf630f170fae4d93a70c.json
+++ b/data/wikidata-cache/a5a4a89ae163cf630f170fae4d93a70c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617656,
+  "timestamp": 1757530499216,
   "ttl": 86400000,
   "query": "Shakespeare wrote",
   "languages": "en",

--- a/data/wikidata-cache/a61a3d8d23f67661a233a6dccec0c9cf.json
+++ b/data/wikidata-cache/a61a3d8d23f67661a233a6dccec0c9cf.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634607789,
+  "timestamp": 1757530492943,
   "ttl": 86400000,
   "query": "visited the",
   "languages": "en",

--- a/data/wikidata-cache/a6c5b7343bd2b50ab9503999f502d4a5.json
+++ b/data/wikidata-cache/a6c5b7343bd2b50ab9503999f502d4a5.json
@@ -2,6 +2,31 @@
   "data": {
     "entities": [
       {
+        "id": "Q145",
+        "title": "Q145",
+        "pageid": 281,
+        "concepturi": "http://www.wikidata.org/entity/Q145",
+        "repository": "wikidata",
+        "url": "//www.wikidata.org/wiki/Q145",
+        "display": {
+          "label": {
+            "value": "United Kingdom",
+            "language": "en"
+          },
+          "description": {
+            "value": "country in north-west Europe",
+            "language": "en"
+          }
+        },
+        "label": "United Kingdom",
+        "description": "country in north-west Europe",
+        "match": {
+          "type": "label",
+          "language": "en",
+          "text": "United Kingdom"
+        }
+      },
+      {
         "id": "Q637413",
         "title": "Q637413",
         "pageid": 599695,
@@ -49,31 +74,6 @@
           "type": "label",
           "language": "en",
           "text": "United States"
-        }
-      },
-      {
-        "id": "Q145",
-        "title": "Q145",
-        "pageid": 281,
-        "concepturi": "http://www.wikidata.org/entity/Q145",
-        "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q145",
-        "display": {
-          "label": {
-            "value": "United Kingdom",
-            "language": "en"
-          },
-          "description": {
-            "value": "country in north-west Europe",
-            "language": "en"
-          }
-        },
-        "label": "United Kingdom",
-        "description": "country in north-west Europe",
-        "match": {
-          "type": "label",
-          "language": "en",
-          "text": "United Kingdom"
         }
       },
       {
@@ -130,7 +130,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1225",
         "title": "Property:P1225",
@@ -228,7 +228,7 @@
         "url": "//www.wikidata.org/wiki/Property:P7063",
         "display": {
           "label": {
-            "value": "U. S. Supreme Court docket number",
+            "value": "U.S. Supreme Court docket number",
             "language": "en"
           },
           "description": {
@@ -236,7 +236,7 @@
             "language": "en"
           }
         },
-        "label": "U. S. Supreme Court docket number",
+        "label": "U.S. Supreme Court docket number",
         "description": "identifier for a case filed at the Supreme Court of the United States",
         "match": {
           "type": "alias",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634613409,
+  "timestamp": 1757530496636,
   "ttl": 86400000,
   "query": "fuzzy_United",
   "languages": "en",

--- a/data/wikidata-cache/a7e5b7b8b405130753b3d4cdd61e51ff.json
+++ b/data/wikidata-cache/a7e5b7b8b405130753b3d4cdd61e51ff.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P1376",
         "title": "Property:P1376",
@@ -141,7 +141,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753619280916,
+  "timestamp": 1757530495057,
   "ttl": 86400000,
   "query": "fuzzy_Paris",
   "languages": "en",

--- a/data/wikidata-cache/a81a6de4d335d96a643a1969d04cc06d.json
+++ b/data/wikidata-cache/a81a6de4d335d96a643a1969d04cc06d.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610254,
+  "timestamp": 1757530494377,
   "ttl": 86400000,
   "query": "fuzzy_relativity",
   "languages": "en",

--- a/data/wikidata-cache/a8df3ae3f874e3b9d5421fd2fdf5397b.json
+++ b/data/wikidata-cache/a8df3ae3f874e3b9d5421fd2fdf5397b.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609557,
+  "timestamp": 1757530493992,
   "ttl": 86400000,
   "query": "theory of",
   "languages": "en",

--- a/data/wikidata-cache/a91390ecf16d60465a394484fb321309.json
+++ b/data/wikidata-cache/a91390ecf16d60465a394484fb321309.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634619052,
+  "timestamp": 1757530500474,
   "ttl": 86400000,
   "query": "Einstein discovered relativity",
   "languages": "en",

--- a/data/wikidata-cache/abe88362be5b7cb34cfb39f393eb64e6.json
+++ b/data/wikidata-cache/abe88362be5b7cb34cfb39f393eb64e6.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P3975",
         "title": "Property:P3975",
@@ -166,7 +166,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634614829,
+  "timestamp": 1757530497057,
   "ttl": 86400000,
   "query": "Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/af9c055ce05dd2abc83f93925f1f53e9.json
+++ b/data/wikidata-cache/af9c055ce05dd2abc83f93925f1f53e9.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494801,
   "ttl": 86400000,
   "query": "Paris is",
   "languages": "en",

--- a/data/wikidata-cache/afca6cdbd005088a2d10805c9187d099.json
+++ b/data/wikidata-cache/afca6cdbd005088a2d10805c9187d099.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634616877,
+  "timestamp": 1757530498349,
   "ttl": 86400000,
   "query": "fuzzy_and became the",
   "languages": "en",

--- a/data/wikidata-cache/b17f5f0e53a063a14b3717ff94c42bbd.json
+++ b/data/wikidata-cache/b17f5f0e53a063a14b3717ff94c42bbd.json
@@ -2,6 +2,31 @@
   "data": {
     "entities": [
       {
+        "id": "Q145",
+        "title": "Q145",
+        "pageid": 281,
+        "concepturi": "http://www.wikidata.org/entity/Q145",
+        "repository": "wikidata",
+        "url": "//www.wikidata.org/wiki/Q145",
+        "display": {
+          "label": {
+            "value": "United Kingdom",
+            "language": "en"
+          },
+          "description": {
+            "value": "country in north-west Europe",
+            "language": "en"
+          }
+        },
+        "label": "United Kingdom",
+        "description": "country in north-west Europe",
+        "match": {
+          "type": "label",
+          "language": "en",
+          "text": "United Kingdom"
+        }
+      },
+      {
         "id": "Q637413",
         "title": "Q637413",
         "pageid": 599695,
@@ -49,31 +74,6 @@
           "type": "label",
           "language": "en",
           "text": "United States"
-        }
-      },
-      {
-        "id": "Q145",
-        "title": "Q145",
-        "pageid": 281,
-        "concepturi": "http://www.wikidata.org/entity/Q145",
-        "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q145",
-        "display": {
-          "label": {
-            "value": "United Kingdom",
-            "language": "en"
-          },
-          "description": {
-            "value": "country in north-west Europe",
-            "language": "en"
-          }
-        },
-        "label": "United Kingdom",
-        "description": "country in north-west Europe",
-        "match": {
-          "type": "label",
-          "language": "en",
-          "text": "United Kingdom"
         }
       },
       {
@@ -130,7 +130,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P1225",
         "title": "Property:P1225",
@@ -228,7 +228,7 @@
         "url": "//www.wikidata.org/wiki/Property:P7063",
         "display": {
           "label": {
-            "value": "U. S. Supreme Court docket number",
+            "value": "U.S. Supreme Court docket number",
             "language": "en"
           },
           "description": {
@@ -236,7 +236,7 @@
             "language": "en"
           }
         },
-        "label": "U. S. Supreme Court docket number",
+        "label": "U.S. Supreme Court docket number",
         "description": "identifier for a case filed at the Supreme Court of the United States",
         "match": {
           "type": "alias",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634612578,
+  "timestamp": 1757530496141,
   "ttl": 86400000,
   "query": "United",
   "languages": "en",

--- a/data/wikidata-cache/b2eed44ce8fa20d99570fcfc4b1171a4.json
+++ b/data/wikidata-cache/b2eed44ce8fa20d99570fcfc4b1171a4.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634614777,
+  "timestamp": 1757530497027,
   "ttl": 86400000,
   "query": "Nations Secretary",
   "languages": "en",

--- a/data/wikidata-cache/b46e49648960f9f0430e4c0ab0d116d0.json
+++ b/data/wikidata-cache/b46e49648960f9f0430e4c0ab0d116d0.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634617992,
+  "timestamp": 1757530499427,
   "ttl": 86400000,
   "query": "Romeo and Juliet",
   "languages": "en",

--- a/data/wikidata-cache/b9e3c6e240e809f7ad66ba74da582f9d.json
+++ b/data/wikidata-cache/b9e3c6e240e809f7ad66ba74da582f9d.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6",
         "title": "Property:P6",
@@ -279,7 +279,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634613249,
+  "timestamp": 1757530496398,
   "ttl": 86400000,
   "query": "fuzzy_president",
   "languages": "en",

--- a/data/wikidata-cache/bad48dd652a5efbe078a5d4d566ac5b1.json
+++ b/data/wikidata-cache/bad48dd652a5efbe078a5d4d566ac5b1.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P2388",
         "title": "Property:P2388",
@@ -195,7 +195,7 @@
     ],
     "total": 7
   },
-  "timestamp": 1753634615486,
+  "timestamp": 1757530497481,
   "ttl": 86400000,
   "query": "fuzzy_Secretary",
   "languages": "en",

--- a/data/wikidata-cache/bc05569ff40e31f7b8af4529960dd91c.json
+++ b/data/wikidata-cache/bc05569ff40e31f7b8af4529960dd91c.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P575",
         "title": "Property:P575",
@@ -121,7 +121,7 @@
     ],
     "total": 4
   },
-  "timestamp": 1753634609215,
+  "timestamp": 1757530493861,
   "ttl": 86400000,
   "query": "discovered",
   "languages": "en",

--- a/data/wikidata-cache/be419be904ebdde3dd11f8abcd7b8a33.json
+++ b/data/wikidata-cache/be419be904ebdde3dd11f8abcd7b8a33.json
@@ -139,10 +139,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616283,
+  "timestamp": 1757530498090,
   "ttl": 86400000,
   "query": "the President",
   "languages": "en",

--- a/data/wikidata-cache/bea73dd909877b55d64e7dbf0a1f9923.json
+++ b/data/wikidata-cache/bea73dd909877b55d64e7dbf0a1f9923.json
@@ -105,32 +105,32 @@
         ]
       },
       {
-        "id": "Q33569",
-        "title": "Q33569",
-        "pageid": 36405,
-        "concepturi": "http://www.wikidata.org/entity/Q33569",
+        "id": "Q697407",
+        "title": "Q697407",
+        "pageid": 656723,
+        "concepturi": "http://www.wikidata.org/entity/Q697407",
         "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Q33569",
+        "url": "//www.wikidata.org/wiki/Q697407",
         "display": {
           "label": {
-            "value": "Hawaiian",
+            "value": "Hawaii Five-O",
             "language": "en"
           },
           "description": {
-            "value": "Polynesian language",
+            "value": "1968 American TV series",
             "language": "en"
           }
         },
-        "label": "Hawaiian",
-        "description": "Polynesian language",
+        "label": "Hawaii Five-O",
+        "description": "1968 American TV series",
         "match": {
           "type": "label",
           "language": "en",
-          "text": "Hawaiian"
+          "text": "Hawaii Five-O"
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P4365",
         "title": "Property:P4365",
@@ -163,7 +163,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634606784,
+  "timestamp": 1757530492179,
   "ttl": 86400000,
   "query": "Hawaii",
   "languages": "en",

--- a/data/wikidata-cache/bf5af601e76a8a9323969b1b82133bcf.json
+++ b/data/wikidata-cache/bf5af601e76a8a9323969b1b82133bcf.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -120,10 +120,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634613179,
+  "timestamp": 1757530496389,
   "ttl": 86400000,
   "query": "fuzzy_president Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/c024ebbcc7580dda49b016837966456f.json
+++ b/data/wikidata-cache/c024ebbcc7580dda49b016837966456f.json
@@ -77,10 +77,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 3
   },
-  "timestamp": 1753634616275,
+  "timestamp": 1757530498089,
   "ttl": 86400000,
   "query": "Hawaii and",
   "languages": "en",

--- a/data/wikidata-cache/c232cbc07590ad10aa55374ad801c409.json
+++ b/data/wikidata-cache/c232cbc07590ad10aa55374ad801c409.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634616893,
+  "timestamp": 1757530498412,
   "ttl": 86400000,
   "query": "fuzzy_became the",
   "languages": "en",

--- a/data/wikidata-cache/c274c5a37fac348c7f3da1e4155220af.json
+++ b/data/wikidata-cache/c274c5a37fac348c7f3da1e4155220af.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634611102,
+  "timestamp": 1757530495023,
   "ttl": 86400000,
   "query": "fuzzy_Paris is the",
   "languages": "en",

--- a/data/wikidata-cache/c378d402b3cfde41aa247b3606fd800e.json
+++ b/data/wikidata-cache/c378d402b3cfde41aa247b3606fd800e.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609526,
+  "timestamp": 1757530494048,
   "ttl": 86400000,
   "query": "fuzzy_Einstein discovered",
   "languages": "en",

--- a/data/wikidata-cache/c707f618799d79e547bf8ab7a470f43c.json
+++ b/data/wikidata-cache/c707f618799d79e547bf8ab7a470f43c.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634611106,
+  "timestamp": 1757530495022,
   "ttl": 86400000,
   "query": "fuzzy_Paris is",
   "languages": "en",

--- a/data/wikidata-cache/cb9d330eb1dfe3c6077119a5df44b99b.json
+++ b/data/wikidata-cache/cb9d330eb1dfe3c6077119a5df44b99b.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617667,
+  "timestamp": 1757530499211,
   "ttl": 86400000,
   "query": "wrote Romeo and",
   "languages": "en",

--- a/data/wikidata-cache/cc143626927d46b100a7819e672a6d25.json
+++ b/data/wikidata-cache/cc143626927d46b100a7819e672a6d25.json
@@ -136,10 +136,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608140,
+  "timestamp": 1757530493159,
   "ttl": 86400000,
   "query": "White House",
   "languages": "en",

--- a/data/wikidata-cache/cc7e55c269ea2cda9c319a6835514756.json
+++ b/data/wikidata-cache/cc7e55c269ea2cda9c319a6835514756.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634618731,
+  "timestamp": 1757530500294,
   "ttl": 86400000,
   "query": "fuzzy_and Juliet",
   "languages": "en",

--- a/data/wikidata-cache/cf76514f4276fd2eb0f9a3defafd4b8d.json
+++ b/data/wikidata-cache/cf76514f4276fd2eb0f9a3defafd4b8d.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6",
         "title": "Property:P6",
@@ -279,7 +279,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634616327,
+  "timestamp": 1757530498520,
   "ttl": 86400000,
   "query": "President",
   "languages": "en",

--- a/data/wikidata-cache/d0028461c8391236066062309cedd5f9.json
+++ b/data/wikidata-cache/d0028461c8391236066062309cedd5f9.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634619059,
+  "timestamp": 1757530500484,
   "ttl": 86400000,
   "query": "discovered relativity",
   "languages": "en",

--- a/data/wikidata-cache/d0107631f0ba2bcb8d556be6f68d2f61.json
+++ b/data/wikidata-cache/d0107631f0ba2bcb8d556be6f68d2f61.json
@@ -27,10 +27,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 1
   },
-  "timestamp": 1753634612868,
+  "timestamp": 1757530495871,
   "ttl": 86400000,
   "query": "of America",
   "languages": "en",

--- a/data/wikidata-cache/d0335f90fcd77f49ef46d93eb3b306b7.json
+++ b/data/wikidata-cache/d0335f90fcd77f49ef46d93eb3b306b7.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -22,7 +22,7 @@
         "description": "president of the United States from 2009 to 2017",
         "match": {
           "type": "label",
-          "language": "en",
+          "language": "mul",
           "text": "Barack Obama"
         }
       },
@@ -130,10 +130,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634607373,
+  "timestamp": 1757530492582,
   "ttl": 86400000,
   "query": "fuzzy_Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/d12ce154b66bb8e8abf90f31cf78c2c9.json
+++ b/data/wikidata-cache/d12ce154b66bb8e8abf90f31cf78c2c9.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P213",
         "title": "Property:P213",
@@ -138,7 +138,7 @@
     ],
     "total": 5
   },
-  "timestamp": 1753634610745,
+  "timestamp": 1757530494780,
   "ttl": 86400000,
   "query": "is",
   "languages": "en",

--- a/data/wikidata-cache/d1605f397c82db5f0484c683bc032ea4.json
+++ b/data/wikidata-cache/d1605f397c82db5f0484c683bc032ea4.json
@@ -11,7 +11,7 @@
         "display": {
           "label": {
             "value": "Barack Obama",
-            "language": "en"
+            "language": "mul"
           },
           "description": {
             "value": "president of the United States from 2009 to 2017",
@@ -22,7 +22,7 @@
         "description": "president of the United States from 2009 to 2017",
         "match": {
           "type": "label",
-          "language": "en",
+          "language": "mul",
           "text": "Barack Obama"
         }
       },
@@ -130,10 +130,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634606704,
+  "timestamp": 1757530492166,
   "ttl": 86400000,
   "query": "Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/d17f4de1fc255cc31bbc8a1fb4832fee.json
+++ b/data/wikidata-cache/d17f4de1fc255cc31bbc8a1fb4832fee.json
@@ -128,10 +128,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634617324,
+  "timestamp": 1757530498505,
   "ttl": 86400000,
   "query": "fuzzy_the President of",
   "languages": "en",

--- a/data/wikidata-cache/d5d12f72aee9b1dc0e10a452291e56d0.json
+++ b/data/wikidata-cache/d5d12f72aee9b1dc0e10a452291e56d0.json
@@ -23,10 +23,10 @@
         "match": {
           "type": "alias",
           "language": "en",
-          "text": "United States of America"
+          "text": "United States of North America"
         },
         "aliases": [
-          "United States of America"
+          "United States of North America"
         ]
       },
       {
@@ -139,10 +139,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634612517,
+  "timestamp": 1757530495907,
   "ttl": 86400000,
   "query": "United States of",
   "languages": "en",

--- a/data/wikidata-cache/d7de967ecb46fae76bf104315ad3a25c.json
+++ b/data/wikidata-cache/d7de967ecb46fae76bf104315ad3a25c.json
@@ -136,7 +136,7 @@
         ]
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P36",
         "title": "Property:P36",
@@ -276,7 +276,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634611122,
+  "timestamp": 1757530494986,
   "ttl": 86400000,
   "query": "capital",
   "languages": "en",

--- a/data/wikidata-cache/d90bf1c25f0c7dc0c20d2889bc7e038c.json
+++ b/data/wikidata-cache/d90bf1c25f0c7dc0c20d2889bc7e038c.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P6617",
         "title": "Property:P6617",
@@ -160,7 +160,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634618731,
+  "timestamp": 1757530499820,
   "ttl": 86400000,
   "query": "fuzzy_Romeo",
   "languages": "en",

--- a/data/wikidata-cache/d9a73645806f1d884ac8b57015dd7963.json
+++ b/data/wikidata-cache/d9a73645806f1d884ac8b57015dd7963.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617994,
+  "timestamp": 1757530499939,
   "ttl": 86400000,
   "query": "and Juliet",
   "languages": "en",

--- a/data/wikidata-cache/db08846ea8065874cf5bbd74950c6bd1.json
+++ b/data/wikidata-cache/db08846ea8065874cf5bbd74950c6bd1.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634613140,
+  "timestamp": 1757530496267,
   "ttl": 86400000,
   "query": "fuzzy_America president Barack",
   "languages": "en",

--- a/data/wikidata-cache/dceab385fd57668946dfdf65f84e2711.json
+++ b/data/wikidata-cache/dceab385fd57668946dfdf65f84e2711.json
@@ -139,10 +139,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616307,
+  "timestamp": 1757530498085,
   "ttl": 86400000,
   "query": "President of the",
   "languages": "en",

--- a/data/wikidata-cache/dd32b7f3b2ce474adadfda0acf5aa71b.json
+++ b/data/wikidata-cache/dd32b7f3b2ce474adadfda0acf5aa71b.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609551,
+  "timestamp": 1757530493999,
   "ttl": 86400000,
   "query": "relativity",
   "languages": "en",

--- a/data/wikidata-cache/df0ad2082e3258f771f4b47d73ff4089.json
+++ b/data/wikidata-cache/df0ad2082e3258f771f4b47d73ff4089.json
@@ -112,10 +112,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634610364,
+  "timestamp": 1757530494585,
   "ttl": 86400000,
   "query": "fuzzy_the theory of",
   "languages": "en",

--- a/data/wikidata-cache/e1450b03b4a940724a083535e585fa04.json
+++ b/data/wikidata-cache/e1450b03b4a940724a083535e585fa04.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634615444,
+  "timestamp": 1757530497515,
   "ttl": 86400000,
   "query": "fuzzy_Nations Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/e1c4ac1fd35a1260cc5ff1186b2243dc.json
+++ b/data/wikidata-cache/e1c4ac1fd35a1260cc5ff1186b2243dc.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P9097",
         "title": "Property:P9097",
@@ -270,7 +270,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634613702,
+  "timestamp": 1757530496402,
   "ttl": 86400000,
   "query": "fuzzy_America",
   "languages": "en",

--- a/data/wikidata-cache/e2e39b16820e5e9e879fab6c02f88a27.json
+++ b/data/wikidata-cache/e2e39b16820e5e9e879fab6c02f88a27.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634615408,
+  "timestamp": 1757530497400,
   "ttl": 86400000,
   "query": "fuzzy_Nations Secretary",
   "languages": "en",

--- a/data/wikidata-cache/e3d1b924662c94a2e8404a7dd6a92842.json
+++ b/data/wikidata-cache/e3d1b924662c94a2e8404a7dd6a92842.json
@@ -130,7 +130,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P9097",
         "title": "Property:P9097",
@@ -270,7 +270,7 @@
     ],
     "total": 10
   },
-  "timestamp": 1753634612579,
+  "timestamp": 1757530495919,
   "ttl": 86400000,
   "query": "America",
   "languages": "en",

--- a/data/wikidata-cache/e7d9ea929b9d2077a6af3ad110ecf0d8.json
+++ b/data/wikidata-cache/e7d9ea929b9d2077a6af3ad110ecf0d8.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634608111,
+  "timestamp": 1757530493115,
   "ttl": 86400000,
   "query": "fuzzy_Obama visited",
   "languages": "en",

--- a/data/wikidata-cache/e8312769e14b860a80b98d266f367d7e.json
+++ b/data/wikidata-cache/e8312769e14b860a80b98d266f367d7e.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634609340,
+  "timestamp": 1757530493922,
   "ttl": 86400000,
   "query": "Einstein discovered the",
   "languages": "en",

--- a/data/wikidata-cache/e887498182ef56d72819b308bb1ffd79.json
+++ b/data/wikidata-cache/e887498182ef56d72819b308bb1ffd79.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610744,
+  "timestamp": 1757530494818,
   "ttl": 86400000,
   "query": "the capital of",
   "languages": "en",

--- a/data/wikidata-cache/e969fefd8f3956082763872f67ec5f40.json
+++ b/data/wikidata-cache/e969fefd8f3956082763872f67ec5f40.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634609705,
+  "timestamp": 1757530494100,
   "ttl": 86400000,
   "query": "theory of relativity",
   "languages": "en",

--- a/data/wikidata-cache/e9e2433e623fe2100b84601ab86e07d0.json
+++ b/data/wikidata-cache/e9e2433e623fe2100b84601ab86e07d0.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P813",
         "title": "Property:P813",
@@ -60,7 +60,7 @@
     ],
     "total": 2
   },
-  "timestamp": 1753634607822,
+  "timestamp": 1757530492958,
   "ttl": 86400000,
   "query": "visited",
   "languages": "en",

--- a/data/wikidata-cache/ea9500cdbf41d4ddc811130f71ee9711.json
+++ b/data/wikidata-cache/ea9500cdbf41d4ddc811130f71ee9711.json
@@ -142,10 +142,10 @@
         ]
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634616280,
+  "timestamp": 1757530498138,
   "ttl": 86400000,
   "query": "the United",
   "languages": "en",

--- a/data/wikidata-cache/eac80ef940f8ce604cbdf21fd6e1c31f.json
+++ b/data/wikidata-cache/eac80ef940f8ce604cbdf21fd6e1c31f.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634617977,
+  "timestamp": 1757530499384,
   "ttl": 86400000,
   "query": "fuzzy_Shakespeare wrote",
   "languages": "en",

--- a/data/wikidata-cache/ee36b3a4b950a2c6354fb809cde37dd6.json
+++ b/data/wikidata-cache/ee36b3a4b950a2c6354fb809cde37dd6.json
@@ -127,10 +127,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634618731,
+  "timestamp": 1757530500143,
   "ttl": 86400000,
   "query": "fuzzy_Romeo and Juliet",
   "languages": "en",

--- a/data/wikidata-cache/ef0cd0bee6ace41ecdf481e343eba901.json
+++ b/data/wikidata-cache/ef0cd0bee6ace41ecdf481e343eba901.json
@@ -130,10 +130,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753619279991,
+  "timestamp": 1757530494345,
   "ttl": 86400000,
   "query": "fuzzy_Einstein",
   "languages": "en",

--- a/data/wikidata-cache/ef3cb531442e69e9ca4fd928d414ada0.json
+++ b/data/wikidata-cache/ef3cb531442e69e9ca4fd928d414ada0.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634606694,
+  "timestamp": 1757530492297,
   "ttl": 86400000,
   "query": "fuzzy_Obama was born",
   "languages": "en",

--- a/data/wikidata-cache/efc7fb8aafc48995e11e78dbcaa2cf29.json
+++ b/data/wikidata-cache/efc7fb8aafc48995e11e78dbcaa2cf29.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P813",
         "title": "Property:P813",
@@ -60,7 +60,7 @@
     ],
     "total": 2
   },
-  "timestamp": 1753634608146,
+  "timestamp": 1757530493198,
   "ttl": 86400000,
   "query": "fuzzy_visited",
   "languages": "en",

--- a/data/wikidata-cache/f27519e07cab19ec3551fcb9d25a3cd7.json
+++ b/data/wikidata-cache/f27519e07cab19ec3551fcb9d25a3cd7.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612500,
+  "timestamp": 1757530495867,
   "ttl": 86400000,
   "query": "America president Barack",
   "languages": "en",

--- a/data/wikidata-cache/f581beb07ed5aa65e47b161008c07ae7.json
+++ b/data/wikidata-cache/f581beb07ed5aa65e47b161008c07ae7.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634610157,
+  "timestamp": 1757530494482,
   "ttl": 86400000,
   "query": "fuzzy_of relativity",
   "languages": "en",

--- a/data/wikidata-cache/f7995b45b9ff07adc188494a1d35d305.json
+++ b/data/wikidata-cache/f7995b45b9ff07adc188494a1d35d305.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634612656,
+  "timestamp": 1757530495936,
   "ttl": 86400000,
   "query": "America president Barack Obama",
   "languages": "en",

--- a/data/wikidata-cache/f9f64784c4e7b3b665a65b5e797871cd.json
+++ b/data/wikidata-cache/f9f64784c4e7b3b665a65b5e797871cd.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634619366,
+  "timestamp": 1757530500653,
   "ttl": 86400000,
   "query": "fuzzy_Einstein discovered relativity",
   "languages": "en",

--- a/data/wikidata-cache/fa6b148dfc47c217512a67986baec085.json
+++ b/data/wikidata-cache/fa6b148dfc47c217512a67986baec085.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634607797,
+  "timestamp": 1757530492908,
   "ttl": 86400000,
   "query": "visited the White",
   "languages": "en",

--- a/data/wikidata-cache/fc926336f31a5058fbb4ac8137f45c75.json
+++ b/data/wikidata-cache/fc926336f31a5058fbb4ac8137f45c75.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "entities": [],
-    "properties": [],
+    "relations": [],
     "total": 0
   },
-  "timestamp": 1753634607797,
+  "timestamp": 1757530492963,
   "ttl": 86400000,
   "query": "Obama visited the",
   "languages": "en",

--- a/data/wikidata-cache/fcdde2d101799426053e321879c6c963.json
+++ b/data/wikidata-cache/fcdde2d101799426053e321879c6c963.json
@@ -133,7 +133,7 @@
         }
       }
     ],
-    "properties": [
+    "relations": [
       {
         "id": "P3975",
         "title": "Property:P3975",
@@ -166,7 +166,7 @@
     ],
     "total": 6
   },
-  "timestamp": 1753634615515,
+  "timestamp": 1757530497492,
   "ttl": 86400000,
   "query": "fuzzy_Secretary General",
   "languages": "en",

--- a/data/wikidata-cache/fe615e675e81beae6b0a4dd632519677.json
+++ b/data/wikidata-cache/fe615e675e81beae6b0a4dd632519677.json
@@ -133,10 +133,10 @@
         }
       }
     ],
-    "properties": [],
+    "relations": [],
     "total": 5
   },
-  "timestamp": 1753634608145,
+  "timestamp": 1757530493153,
   "ttl": 86400000,
   "query": "White",
   "languages": "en",

--- a/data/wikidata-cache/ff76fe7b84b3605e0138091287f99d43.json
+++ b/data/wikidata-cache/ff76fe7b84b3605e0138091287f99d43.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "entities": [],
-    "properties": [
+    "relations": [
       {
         "id": "P19",
         "title": "Property:P19",
@@ -34,7 +34,7 @@
     ],
     "total": 1
   },
-  "timestamp": 1753634606739,
+  "timestamp": 1757530492350,
   "ttl": 86400000,
   "query": "fuzzy_born in",
   "languages": "en",

--- a/properties.html
+++ b/properties.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Wikidata Property Viewer</title>
+  <title>Wikidata Relations Viewer</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
@@ -431,7 +431,7 @@
               </button>
             ))}
           </div>
-          <div className="watermark">property</div>
+          <div className="watermark">relations</div>
         </div>
       );
     }

--- a/run-test.mjs
+++ b/run-test.mjs
@@ -3,7 +3,7 @@
 // Node.js test runner for Text to Q/P Transformer
 // Run with: bun run-test.mjs
 
-import { TextToQPTransformer } from './text-to-qp-transformer.js';
+import { TextToQPTransformer } from './transformation/text-to-qp-transformer.js';
 
 /**
  * Mock Wikidata API responses for testing - Updated based on E2E findings
@@ -17,7 +17,7 @@ class MockWikidataAPIClient {
           { id: 'Q76', label: 'Barack Obama', description: 'president of the United States from 2009 to 2017' },
           { id: 'Q18643532', label: 'Barack', description: 'male given name' }
         ],
-        properties: []
+        relations: []
       },
       'Barack': {
         entities: [
@@ -25,7 +25,7 @@ class MockWikidataAPIClient {
           { id: 'Q18643532', label: 'Barack', description: 'male given name' },
           { id: 'Q37011990', label: 'Barack', description: 'family name' }
         ],
-        properties: []
+        relations: []
       },
       'Obama': {
         entities: [
@@ -33,7 +33,7 @@ class MockWikidataAPIClient {
           { id: 'Q76', label: 'Barack Obama', description: 'president of the United States from 2009 to 2017' },
           { id: 'Q41773', label: 'Obama', description: 'city in Japan' }
         ],
-        properties: []
+        relations: []
       },
       'Hawaii': {
         entities: [
@@ -41,7 +41,7 @@ class MockWikidataAPIClient {
           { id: 'Q18703903', label: 'Hawaii', description: 'volcanic island chain in the Pacific Ocean' },
           { id: 'Q68740', label: 'Hawaii', description: 'largest island of Hawaii' }
         ],
-        properties: []
+        relations: []
       },
       'born': {
         entities: [
@@ -66,13 +66,13 @@ class MockWikidataAPIClient {
           { id: 'Q937', label: 'Albert Einstein', description: 'German-born theoretical physicist' },
           { id: 'Q1309274', label: 'Einstein', description: 'municipality in Switzerland' }
         ],
-        properties: []
+        relations: []
       },
       'Albert Einstein': {
         entities: [
           { id: 'Q937', label: 'Albert Einstein', description: 'German-born theoretical physicist' }
         ],
-        properties: []
+        relations: []
       },
       'Paris': {
         entities: [
@@ -100,7 +100,7 @@ class MockWikidataAPIClient {
           { id: 'Q3080569', label: 'France', description: 'family name' },
           { id: 'Q16275867', label: 'France', description: 'commune in Lot, France' }
         ],
-        properties: []
+        relations: []
       }
     };
   }

--- a/search-demo.html
+++ b/search-demo.html
@@ -234,7 +234,7 @@
 <body>
     <div class="header">
         <h1>🔍 Wikidata Search & Disambiguation Demo</h1>
-        <p>Search for entities and properties with exact matching and fuzzy search capabilities</p>
+        <p>Search for entities and relations with exact matching and fuzzy search capabilities</p>
     </div>
 
     <div class="search-container">
@@ -261,9 +261,9 @@
             <div class="option-group">
                 <label for="searchType">Search Type:</label>
                 <select id="searchType">
-                    <option value="both">Both Entities & Properties</option>
+                    <option value="both">Both Entities & Relations</option>
                     <option value="item">Entities Only</option>
-                    <option value="property">Properties Only</option>
+                    <option value="property">Relations Only</option>
                 </select>
             </div>
 
@@ -392,7 +392,7 @@
                 items = results.combined || [];
                 resultsCount.textContent = `${results.total} results (${results.exact.length} exact, ${results.fuzzy.length} fuzzy)`;
             } else {
-                items = [...(results.entities || []), ...(results.properties || [])];
+                items = [...(results.entities || []), ...(results.relations || [])];
                 resultsCount.textContent = `${items.length} results`;
             }
 
@@ -403,7 +403,7 @@
 
             const resultsHtml = items.map(item => {
                 const typeClass = item.id.startsWith('P') ? 'type-property' : 'type-entity';
-                const typeText = item.id.startsWith('P') ? 'Property' : 'Entity';
+                const typeText = item.id.startsWith('P') ? 'Relation' : 'Entity';
                 const matchClass = item.matchType === 'exact' ? 'match-exact' : 'match-fuzzy';
                 const matchText = item.matchType || '';
 

--- a/transformation/index.html
+++ b/transformation/index.html
@@ -382,7 +382,7 @@
   <header>
     <div class="container">
       <h1>🔄 Text to Wikidata Q/P Transformer</h1>
-      <p class="subtitle">Transform English text into sequences of Wikidata entities (Q) and properties (P)</p>
+      <p class="subtitle">Transform English text into sequences of Wikidata entities (Q) and relations (P)</p>
     </div>
   </header>
 
@@ -408,7 +408,7 @@
             </div>
             <div class="option">
               <input type="checkbox" id="preferProperties" name="preferProperties">
-              <label for="preferProperties">Prefer properties</label>
+              <label for="preferProperties">Prefer relations</label>
             </div>
             <div class="option">
               <label for="maxCandidates">Max candidates:</label>

--- a/transformation/text-to-qp-transformer.js
+++ b/transformation/text-to-qp-transformer.js
@@ -1,5 +1,5 @@
 // Text to Wikidata Q/P Transformer
-// Transforms English text into sequences of Wikidata entities (Q) and properties (P)
+// Transforms English text into sequences of Wikidata entities (Q) and relations (P)
 // with disambiguation support using [Q1 or Q2 or Q3] syntax
 
 // Import appropriate API based on environment
@@ -26,7 +26,7 @@ class TextToQPTransformer {
     this.apiClient = new WikidataAPIClient();
     this.searchUtility = new WikidataSearchUtility(this.apiClient, null, null);
     
-    // Common English words that should be properties
+    // Common English words that should be relations
     this.propertyIndicators = [
       'is', 'was', 'are', 'were', 'has', 'have', 'had',
       'born', 'died', 'located', 'created', 'founded',
@@ -145,7 +145,7 @@ class TextToQPTransformer {
   /**
    * Search for all n-grams in parallel
    * @param {Object} ngrams - N-grams organized by size
-   * @param {boolean} preferProperties - Whether to prefer properties
+   * @param {boolean} preferProperties - Whether to prefer relations
    * @param {number} searchLimit - Search limit
    * @returns {Promise<Array>} - Array of n-gram results with search matches
    */
@@ -240,7 +240,7 @@ class TextToQPTransformer {
   /**
    * Search for a term in Wikidata
    * @param {string} term - Term to search for
-   * @param {boolean} preferProperties - Whether to prefer properties over entities
+   * @param {boolean} preferProperties - Whether to prefer relations over entities
    * @param {number} limit - Maximum number of results
    * @returns {Promise<Object>} - Search results
    */

--- a/wikidata-api-browser.js
+++ b/wikidata-api-browser.js
@@ -12,7 +12,7 @@ const CACHE_CONFIG = {
   VERSION: 1,
   STORES: {
     ENTITIES: 'entities',
-    PROPERTIES: 'properties'
+    PROPERTIES: 'relations'
   }
 };
 
@@ -52,7 +52,7 @@ class WikidataAPIClient {
   /**
    * Fetch entities from Wikidata API
    * @param {string|Array} ids - Entity IDs to fetch
-   * @param {string} props - Properties to fetch (labels|descriptions|claims)
+   * @param {string} props - Relations to fetch (labels|descriptions|claims)
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - API response
    */
@@ -74,7 +74,7 @@ class WikidataAPIClient {
   }
 
   /**
-   * Fetch a single entity with all properties
+   * Fetch a single entity with all relations
    * @param {string} entityId - Entity ID (e.g., 'Q42')
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - Entity data
@@ -107,12 +107,12 @@ class WikidataAPIClient {
   }
 
   /**
-   * Search for entities and properties that match an exact word sequence
+   * Search for entities and relations that match an exact word sequence
    * @param {string} query - Exact word sequence to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchExactMatch(query, languages = 'en', limit = 50, type = 'both') {
     // Check cache first
@@ -125,7 +125,7 @@ class WikidataAPIClient {
     console.log(`API call for: ${query}`);
     const results = {
       entities: [],
-      properties: [],
+      relations: [],
       total: 0
     };
 
@@ -148,7 +148,7 @@ class WikidataAPIClient {
         }
       }
 
-      // Search for properties
+      // Search for relations
       if (type === 'both' || type === 'property') {
         const propertyUrl = this.buildApiUrl({
           action: 'wbsearchentities',
@@ -162,11 +162,11 @@ class WikidataAPIClient {
         const propertyResponse = await fetch(propertyUrl);
         if (propertyResponse.ok) {
           const propertyData = await propertyResponse.json();
-          results.properties = propertyData.search || [];
+          results.relations = propertyData.search || [];
         }
       }
 
-      results.total = results.entities.length + results.properties.length;
+      results.total = results.entities.length + results.relations.length;
       
       // Cache the results for 24 hours
       await this.cache.set(query, results, languages, limit, type, 24 * 60 * 60 * 1000);
@@ -180,12 +180,12 @@ class WikidataAPIClient {
   }
 
   /**
-   * Search for entities and properties with fuzzy matching
+   * Search for entities and relations with fuzzy matching
    * @param {string} query - Query string to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchFuzzy(query, languages = 'en', limit = 50, type = 'both') {
     // Check cache first
@@ -200,7 +200,7 @@ class WikidataAPIClient {
     
     const results = {
       entities: [],
-      properties: [],
+      relations: [],
       total: 0
     };
 
@@ -223,7 +223,7 @@ class WikidataAPIClient {
         }
       }
 
-      // Search for properties
+      // Search for relations
       if (type === 'both' || type === 'property') {
         const propertyUrl = this.buildApiUrl({
           action: 'wbsearchentities',
@@ -237,11 +237,11 @@ class WikidataAPIClient {
         const propertyResponse = await fetch(propertyUrl);
         if (propertyResponse.ok) {
           const propertyData = await propertyResponse.json();
-          results.properties = propertyData.search || [];
+          results.relations = propertyData.search || [];
         }
       }
 
-      results.total = results.entities.length + results.properties.length;
+      results.total = results.entities.length + results.relations.length;
       
       // Cache the results for 24 hours
       await this.cache.set(cacheKey, results, languages, limit, type, 24 * 60 * 60 * 1000);
@@ -293,7 +293,7 @@ class WikidataCacheManager {
 
   /**
    * Get data from cache
-   * @param {string} storeName - Store name (entities or properties)
+   * @param {string} storeName - Store name (entities or relations)
    * @param {string} id - Entity/Property ID
    * @returns {Promise<Object|null>} - Cached data or null
    */
@@ -316,7 +316,7 @@ class WikidataCacheManager {
 
   /**
    * Save data to cache
-   * @param {string} storeName - Store name (entities or properties)
+   * @param {string} storeName - Store name (entities or relations)
    * @param {string} id - Entity/Property ID
    * @param {Object} data - Data to cache
    * @returns {Promise<void>}
@@ -353,7 +353,7 @@ class WikidataCacheManager {
     const hasLabels = data.labels && Object.keys(data.labels).length > 0;
     const hasDescriptions = data.descriptions && Object.keys(data.descriptions).length > 0;
     
-    // For properties, we also want to check if we have claims data
+    // For relations, we also want to check if we have claims data
     const hasClaims = data.claims && Object.keys(data.claims).length > 0;
     
     return hasLabels && hasDescriptions && hasClaims;
@@ -418,8 +418,8 @@ class WikidataDataProcessor {
 }
 
 /**
- * Label Manager for Wikidata entities and properties
- * Handles loading and caching of labels for entities and properties referenced in statements
+ * Label Manager for Wikidata entities and relations
+ * Handles loading and caching of labels for entities and relations referenced in statements
  */
 class WikidataLabelManager {
   constructor(apiClient, cacheManager, dataProcessor) {
@@ -429,7 +429,7 @@ class WikidataLabelManager {
   }
 
   /**
-   * Load all labels for entities and properties referenced in statements
+   * Load all labels for entities and relations referenced in statements
    * @param {Object} claims - Claims object from Wikidata
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - Object with propertyLabels and entityLabels
@@ -531,7 +531,7 @@ class WikidataLabelManager {
 
 /**
  * Wikidata Search and Disambiguation Utility
- * Provides advanced search and disambiguation functionality for entities and properties
+ * Provides advanced search and disambiguation functionality for entities and relations
  */
 class WikidataSearchUtility {
   constructor(apiClient, cacheManager, dataProcessor) {
@@ -541,24 +541,24 @@ class WikidataSearchUtility {
   }
 
   /**
-   * Search for entities and properties with exact word sequence matching
+   * Search for entities and relations with exact word sequence matching
    * @param {string} query - Exact word sequence to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchExactMatch(query, languages = 'en', limit = 50, type = 'both') {
     return await this.apiClient.searchExactMatch(query, languages, limit, type);
   }
 
   /**
-   * Search for entities and properties with fuzzy matching
+   * Search for entities and relations with fuzzy matching
    * @param {string} query - Query string to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchFuzzy(query, languages = 'en', limit = 50, type = 'both') {
     return await this.apiClient.searchFuzzy(query, languages, limit, type);
@@ -589,9 +589,9 @@ class WikidataSearchUtility {
 
       // Combine and rank results
       const exactEntities = exactResults.entities || [];
-      const exactProperties = exactResults.properties || [];
+      const exactRelations = exactResults.relations || [];
       const fuzzyEntities = fuzzyResults.entities || [];
-      const fuzzyProperties = fuzzyResults.properties || [];
+      const fuzzyRelations = fuzzyResults.relations || [];
 
       // Create a map to avoid duplicates
       const seenIds = new Set();
@@ -604,7 +604,7 @@ class WikidataSearchUtility {
         }
       });
 
-      exactProperties.forEach(property => {
+      exactRelations.forEach(property => {
         if (!seenIds.has(property.id)) {
           seenIds.add(property.id);
           results.exact.push({ ...property, matchType: 'exact' });
@@ -619,7 +619,7 @@ class WikidataSearchUtility {
         }
       });
 
-      fuzzyProperties.forEach(property => {
+      fuzzyRelations.forEach(property => {
         if (!seenIds.has(property.id)) {
           seenIds.add(property.id);
           results.fuzzy.push({ ...property, matchType: 'fuzzy' });

--- a/wikidata-api.js
+++ b/wikidata-api.js
@@ -13,7 +13,7 @@ const CACHE_CONFIG = {
   VERSION: 1,
   STORES: {
     ENTITIES: 'entities',
-    PROPERTIES: 'properties'
+    PROPERTIES: 'relations'
   }
 };
 
@@ -53,7 +53,7 @@ class WikidataAPIClient {
   /**
    * Fetch entities from Wikidata API
    * @param {string|Array} ids - Entity IDs to fetch
-   * @param {string} props - Properties to fetch (labels|descriptions|claims)
+   * @param {string} props - Relations to fetch (labels|descriptions|claims)
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - API response
    */
@@ -75,7 +75,7 @@ class WikidataAPIClient {
   }
 
   /**
-   * Fetch a single entity with all properties
+   * Fetch a single entity with all relations
    * @param {string} entityId - Entity ID (e.g., 'Q42')
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - Entity data
@@ -108,12 +108,12 @@ class WikidataAPIClient {
   }
 
   /**
-   * Search for entities and properties that match an exact word sequence
+   * Search for entities and relations that match an exact word sequence
    * @param {string} query - Exact word sequence to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchExactMatch(query, languages = 'en', limit = 50, type = 'both') {
     // Check cache first
@@ -126,7 +126,7 @@ class WikidataAPIClient {
     console.log(`API call for: ${query}`);
     const results = {
       entities: [],
-      properties: [],
+      relations: [],
       total: 0
     };
 
@@ -149,7 +149,7 @@ class WikidataAPIClient {
         }
       }
 
-      // Search for properties
+      // Search for relations
       if (type === 'both' || type === 'property') {
         const propertyUrl = this.buildApiUrl({
           action: 'wbsearchentities',
@@ -163,11 +163,11 @@ class WikidataAPIClient {
         const propertyResponse = await fetch(propertyUrl);
         if (propertyResponse.ok) {
           const propertyData = await propertyResponse.json();
-          results.properties = propertyData.search || [];
+          results.relations = propertyData.search || [];
         }
       }
 
-      results.total = results.entities.length + results.properties.length;
+      results.total = results.entities.length + results.relations.length;
       
       // Cache the results for 24 hours
       await this.cache.set(query, results, languages, limit, type, 24 * 60 * 60 * 1000);
@@ -181,17 +181,17 @@ class WikidataAPIClient {
   }
 
   /**
-   * Search for entities and properties with fuzzy matching
+   * Search for entities and relations with fuzzy matching
    * @param {string} query - Query string to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchFuzzy(query, languages = 'en', limit = 50, type = 'both') {
     const results = {
       entities: [],
-      properties: [],
+      relations: [],
       total: 0
     };
 
@@ -224,7 +224,7 @@ class WikidataAPIClient {
         }
       }
 
-      // Search for properties
+      // Search for relations
       if (type === 'both' || type === 'property') {
         const propertyUrl = this.buildApiUrl({
           action: 'wbsearchentities',
@@ -238,11 +238,11 @@ class WikidataAPIClient {
         const propertyResponse = await fetch(propertyUrl);
         if (propertyResponse.ok) {
           const propertyData = await propertyResponse.json();
-          results.properties = propertyData.search || [];
+          results.relations = propertyData.search || [];
         }
       }
 
-      results.total = results.entities.length + results.properties.length;
+      results.total = results.entities.length + results.relations.length;
       
       // Cache the results for 24 hours
       await this.cache.set(cacheKey, results, languages, limit, type, 24 * 60 * 60 * 1000);
@@ -294,7 +294,7 @@ class WikidataCacheManager {
 
   /**
    * Get data from cache
-   * @param {string} storeName - Store name (entities or properties)
+   * @param {string} storeName - Store name (entities or relations)
    * @param {string} id - Entity/Property ID
    * @returns {Promise<Object|null>} - Cached data or null
    */
@@ -317,7 +317,7 @@ class WikidataCacheManager {
 
   /**
    * Save data to cache
-   * @param {string} storeName - Store name (entities or properties)
+   * @param {string} storeName - Store name (entities or relations)
    * @param {string} id - Entity/Property ID
    * @param {Object} data - Data to cache
    * @returns {Promise<void>}
@@ -354,7 +354,7 @@ class WikidataCacheManager {
     const hasLabels = data.labels && Object.keys(data.labels).length > 0;
     const hasDescriptions = data.descriptions && Object.keys(data.descriptions).length > 0;
     
-    // For properties, we also want to check if we have claims data
+    // For relations, we also want to check if we have claims data
     const hasClaims = data.claims && Object.keys(data.claims).length > 0;
     
     return hasLabels && hasDescriptions && hasClaims;
@@ -458,7 +458,7 @@ class WikidataDataProcessor {
 
 /**
  * Wikidata Search and Disambiguation Utility
- * Provides advanced search and disambiguation functionality for entities and properties
+ * Provides advanced search and disambiguation functionality for entities and relations
  */
 class WikidataSearchUtility {
   constructor(apiClient, cacheManager, dataProcessor) {
@@ -468,24 +468,24 @@ class WikidataSearchUtility {
   }
 
   /**
-   * Search for entities and properties with exact word sequence matching
+   * Search for entities and relations with exact word sequence matching
    * @param {string} query - Exact word sequence to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchExactMatch(query, languages = 'en', limit = 50, type = 'both') {
     return await this.apiClient.searchExactMatch(query, languages, limit, type);
   }
 
   /**
-   * Search for entities and properties with fuzzy matching
+   * Search for entities and relations with fuzzy matching
    * @param {string} query - Query string to search for
    * @param {string} languages - Languages to search in (default: 'en')
    * @param {number} limit - Maximum number of results (default: 50)
    * @param {string} type - Type to search for: 'item', 'property', or 'both' (default: 'both')
-   * @returns {Promise<Object>} - Search results with entities and properties
+   * @returns {Promise<Object>} - Search results with entities and relations
    */
   async searchFuzzy(query, languages = 'en', limit = 50, type = 'both') {
     return await this.apiClient.searchFuzzy(query, languages, limit, type);
@@ -516,9 +516,9 @@ class WikidataSearchUtility {
 
       // Combine and rank results
       const exactEntities = exactResults.entities || [];
-      const exactProperties = exactResults.properties || [];
+      const exactRelations = exactResults.relations || [];
       const fuzzyEntities = fuzzyResults.entities || [];
-      const fuzzyProperties = fuzzyResults.properties || [];
+      const fuzzyRelations = fuzzyResults.relations || [];
 
       // Create a map to avoid duplicates
       const seenIds = new Set();
@@ -531,7 +531,7 @@ class WikidataSearchUtility {
         }
       });
 
-      exactProperties.forEach(property => {
+      exactRelations.forEach(property => {
         if (!seenIds.has(property.id)) {
           seenIds.add(property.id);
           results.exact.push({ ...property, matchType: 'exact' });
@@ -546,7 +546,7 @@ class WikidataSearchUtility {
         }
       });
 
-      fuzzyProperties.forEach(property => {
+      fuzzyRelations.forEach(property => {
         if (!seenIds.has(property.id)) {
           seenIds.add(property.id);
           results.fuzzy.push({ ...property, matchType: 'fuzzy' });
@@ -631,8 +631,8 @@ class WikidataSearchUtility {
 }
 
 /**
- * Label Manager for Wikidata entities and properties
- * Handles loading and caching of labels for entities and properties referenced in statements
+ * Label Manager for Wikidata entities and relations
+ * Handles loading and caching of labels for entities and relations referenced in statements
  */
 class WikidataLabelManager {
   constructor(apiClient, cacheManager, dataProcessor) {
@@ -642,7 +642,7 @@ class WikidataLabelManager {
   }
 
   /**
-   * Load all labels for entities and properties referenced in statements
+   * Load all labels for entities and relations referenced in statements
    * @param {Object} claims - Claims object from Wikidata
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - Object with propertyLabels and entityLabels


### PR DESCRIPTION
## Summary

This PR implements issue #12 to rename "properties" to "relations" throughout the codebase for better semantic clarity in the human language processing context.

### Changes Made

- **Cache System**: Updated cache store names from 'properties' to 'relations'
- **API Layer**: Changed search result arrays to use 'relations' instead of 'properties'
- **User Interface**: Updated UI labels from 'Properties' to 'Relations' in search interface
- **HTML Pages**: Updated Wikidata Relations Viewer title (formerly Property Viewer)
- **Documentation**: Updated comments and documentation to use 'relations' terminology
- **Transformation**: Updated transformation interface labels and descriptions
- **README**: Updated project documentation to reflect Relations terminology

### Files Modified

- `wikidata-api.js` and `wikidata-api-browser.js` - Core API changes
- `search-demo.html` - UI label updates
- `properties.html` - Title and watermark updates
- `transformation/` - Text transformation interface updates
- `README.md` - Documentation updates
- `run-test.mjs` - Test mock data updates

### Testing

- ✅ Basic test suite passes
- ✅ Text transformation functionality working
- ✅ Search interface displays "Relations" instead of "Properties"
- ✅ Cache system uses new 'relations' store name

The change improves semantic clarity by using "relations" instead of "properties" to describe the connections between Wikidata entities, which is more intuitive for users understanding knowledge graph relationships.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #12