### PR TITLE
feat: Support switching between alternative words/names for entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/human-language/issues/10
+Your prepared branch: issue-10-2c4d2ebc
+Your prepared working directory: /tmp/gh-issue-solver-1757531570424
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/human-language/issues/10
-Your prepared branch: issue-10-2c4d2ebc
-Your prepared working directory: /tmp/gh-issue-solver-1757531570424
-
-Proceed.

--- a/entities.html
+++ b/entities.html
@@ -255,6 +255,8 @@
       const [entityId, setEntityId] = React.useState(window.location.hash.slice(1) || 'Q35120');
       const [labels, setLabels] = React.useState({});
       const [descriptions, setDescriptions] = React.useState({});
+      const [aliases, setAliases] = React.useState({});
+      const [selectedLabelIndex, setSelectedLabelIndex] = React.useState(0);
       const [statements, setStatements] = React.useState([]);
       const [preferredLanguages, setPreferredLanguages] = React.useState([]);
       const [availableLanguages, setAvailableLanguages] = React.useState([]);
@@ -293,6 +295,8 @@
           setStatements({});
           setLabels({});
           setDescriptions({});
+          setAliases({});
+          setSelectedLabelIndex(0);
           setAvailableLanguages([]);
         };
         window.addEventListener('hashchange', handleHashChange);
@@ -340,6 +344,7 @@
               console.log('Claims object:', entityData.claims);
               setLabels(entityData.labels || {});
               setDescriptions(entityData.descriptions || {});
+              setAliases(entityData.aliases || {});
               setStatements(entityData.claims || {});
               const langSet = new Set([...Object.keys(entityData.labels || {}), ...Object.keys(entityData.descriptions || {})]);
               setAvailableLanguages(Array.from(langSet).sort());
@@ -358,6 +363,7 @@
               console.log('No entity data found for:', entityId);
               setLabels({});
               setDescriptions({});
+              setAliases({});
               setStatements({});
               setAvailableLanguages([]);
               const savedLanguage = loadFromLocalStorage(STORAGE_KEYS.LANGUAGE, null);
@@ -369,6 +375,7 @@
             console.error('Error fetching data:', error);
             setLabels({});
             setDescriptions({});
+            setAliases({});
             setStatements({});
             setAvailableLanguages([]);
             const savedLanguage = loadFromLocalStorage(STORAGE_KEYS.LANGUAGE, null);
@@ -380,6 +387,11 @@
         loadEntityData();
       }, [entityId]);
 
+      // Reset label index when language changes
+      React.useEffect(() => {
+        setSelectedLabelIndex(0);
+      }, [selectedLanguage]);
+
       const toggleTheme = () => {
         setTheme(prevTheme => prevTheme === 'dark' ? 'light' : 'dark');
         saveToLocalStorage(STORAGE_KEYS.THEME, prevTheme === 'dark' ? 'light' : 'dark');
@@ -390,7 +402,19 @@
 
       console.log('Loading state:', { isLoading, propertyLabelsCount: Object.keys(propertyLabels).length, entityLabelsCount: Object.keys(entityLabels).length, statementsCount: Object.keys(statements).length });
       
-      const currentLabel = labels[selectedLanguage]?.value || 'No label available';
+      // Create list of available labels (main label + aliases) for current language
+      const availableLabels = [];
+      const mainLabel = labels[selectedLanguage]?.value;
+      if (mainLabel) {
+        availableLabels.push({ type: 'main', value: mainLabel, display: mainLabel });
+      }
+      
+      const currentAliases = aliases[selectedLanguage] || [];
+      currentAliases.forEach((alias, index) => {
+        availableLabels.push({ type: 'alias', value: alias.value, display: `${alias.value} (alias)` });
+      });
+      
+      const currentLabel = availableLabels[selectedLabelIndex]?.value || mainLabel || 'No label available';
       const otherLabels = preferredLanguages.filter(lang => lang !== selectedLanguage && labels[lang]);
       const sortedLanguages = [selectedLanguage, ...otherLabels];
       const descriptionsList = sortedLanguages.map(lang => descriptions[lang]?.value).filter(desc => desc);
@@ -405,7 +429,30 @@
             {theme === 'dark' ? '☀️' : '🌙'}
           </button>
           <main>
-            <h1>{currentLabel}</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '20px', marginBottom: '30px' }}>
+              <h1 style={{ margin: '0' }}>{currentLabel}</h1>
+              {availableLabels.length > 1 && (
+                <select 
+                  value={selectedLabelIndex}
+                  onChange={(e) => setSelectedLabelIndex(parseInt(e.target.value))}
+                  style={{
+                    backgroundColor: 'var(--header-bg)',
+                    color: 'var(--text)',
+                    border: '1px solid var(--neon)',
+                    borderRadius: '4px',
+                    padding: '8px',
+                    fontSize: '1rem',
+                    fontFamily: 'Orbitron, sans-serif'
+                  }}
+                >
+                  {availableLabels.map((label, index) => (
+                    <option key={index} value={index}>
+                      {label.display}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
             {otherLabels.map(lang => (
               <h2 key={lang}>{labels[lang]?.value || 'No label available'}</h2>
             ))}

--- a/properties.html
+++ b/properties.html
@@ -246,6 +246,8 @@
       const [propertyId, setPropertyId] = React.useState(window.location.hash.slice(1) || 'P31');
       const [labels, setLabels] = React.useState({});
       const [descriptions, setDescriptions] = React.useState({});
+      const [aliases, setAliases] = React.useState({});
+      const [selectedLabelIndex, setSelectedLabelIndex] = React.useState(0);
       const [preferredLanguages, setPreferredLanguages] = React.useState([]);
       const [availableLanguages, setAvailableLanguages] = React.useState([]);
       const [selectedLanguage, setSelectedLanguage] = React.useState('');
@@ -314,6 +316,7 @@
               
               setLabels(property.labels || {});
               setDescriptions(property.descriptions || {});
+              setAliases(property.aliases || {});
               setStatements(property.claims || {});
               console.log('Property claims loaded:', property.claims);
               const langSet = new Set([...Object.keys(property.labels || {}), ...Object.keys(property.descriptions || {})]);
@@ -330,6 +333,7 @@
             } else {
               setLabels({});
               setDescriptions({});
+              setAliases({});
               setStatements({});
               setAvailableLanguages([]);
               const savedLanguage = loadFromLocalStorage(STORAGE_KEYS.LANGUAGE, null);
@@ -346,6 +350,7 @@
             console.error('Error fetching data:', error);
             setLabels({});
             setDescriptions({});
+            setAliases({});
             setStatements({});
             setAvailableLanguages([]);
             const savedLanguage = loadFromLocalStorage(STORAGE_KEYS.LANGUAGE, null);
@@ -353,6 +358,11 @@
             setIsLoading(false);
           });
       }, [propertyId]);
+
+      // Reset label index when language changes
+      React.useEffect(() => {
+        setSelectedLabelIndex(0);
+      }, [selectedLanguage]);
 
       const toggleTheme = () => {
         setTheme(prevTheme => {
@@ -369,7 +379,19 @@
       const { StatementsSection } = window.StatementComponents;
       const { LoadingComponent } = window.LoadingComponents;
 
-      const currentLabel = labels[selectedLanguage]?.value || 'No label available';
+      // Create list of available labels (main label + aliases) for current language
+      const availableLabels = [];
+      const mainLabel = labels[selectedLanguage]?.value;
+      if (mainLabel) {
+        availableLabels.push({ type: 'main', value: mainLabel, display: mainLabel });
+      }
+      
+      const currentAliases = aliases[selectedLanguage] || [];
+      currentAliases.forEach((alias, index) => {
+        availableLabels.push({ type: 'alias', value: alias.value, display: `${alias.value} (alias)` });
+      });
+      
+      const currentLabel = availableLabels[selectedLabelIndex]?.value || mainLabel || 'No label available';
       const otherLabels = preferredLanguages.filter(lang => lang !== selectedLanguage && labels[lang]);
       const sortedLanguages = [selectedLanguage, ...otherLabels];
       const descriptionsList = sortedLanguages.map(lang => descriptions[lang]?.value).filter(desc => desc);
@@ -385,7 +407,30 @@
             {theme === 'dark' ? '☀️' : '🌙'}
           </button>
           <main>
-            <h1>{currentLabel}</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '20px', marginBottom: '30px' }}>
+              <h1 style={{ margin: '0' }}>{currentLabel}</h1>
+              {availableLabels.length > 1 && (
+                <select 
+                  value={selectedLabelIndex}
+                  onChange={(e) => setSelectedLabelIndex(parseInt(e.target.value))}
+                  style={{
+                    backgroundColor: 'var(--header-bg)',
+                    color: 'var(--text)',
+                    border: '1px solid var(--neon)',
+                    borderRadius: '4px',
+                    padding: '8px',
+                    fontSize: '1rem',
+                    fontFamily: 'Orbitron, sans-serif'
+                  }}
+                >
+                  {availableLabels.map((label, index) => (
+                    <option key={index} value={index}>
+                      {label.display}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
             {otherLabels.map(lang => (
               <h2 key={lang}>{labels[lang]?.value || 'No label available'}</h2>
             ))}

--- a/test-aliases.html
+++ b/test-aliases.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Aliases Implementation</title>
+    <style>
+        body { 
+            font-family: Arial, sans-serif; 
+            margin: 20px; 
+            background: #f5f5f5; 
+        }
+        .test-result { 
+            padding: 10px; 
+            margin: 10px 0; 
+            border-radius: 4px; 
+        }
+        .success { background: #d4edda; color: #155724; }
+        .error { background: #f8d7da; color: #721c24; }
+        .info { background: #d1ecf1; color: #0c5460; }
+    </style>
+</head>
+<body>
+    <h1>Aliases Implementation Test</h1>
+    
+    <div id="results"></div>
+    
+    <script type="module">
+        import { WikidataAPIClient } from './wikidata-api-browser.js';
+        
+        const results = document.getElementById('results');
+        
+        function addResult(message, type = 'info') {
+            const div = document.createElement('div');
+            div.className = `test-result ${type}`;
+            div.textContent = message;
+            results.appendChild(div);
+        }
+        
+        async function testAliases() {
+            try {
+                addResult('Starting aliases test...');
+                
+                const client = new WikidataAPIClient();
+                
+                // Test Q35120 (entity) which should have aliases
+                addResult('Fetching Q35120 (entity)...');
+                const entity = await client.fetchEntity('Q35120', 'en');
+                
+                if (!entity) {
+                    addResult('ERROR: No entity data returned', 'error');
+                    return;
+                }
+                
+                addResult(`Entity ID: ${entity.id}`, 'info');
+                addResult(`Main label: ${entity.labels?.en?.value || 'No label'}`, 'info');
+                
+                if (entity.aliases && entity.aliases.en) {
+                    addResult(`Found ${entity.aliases.en.length} aliases:`, 'success');
+                    entity.aliases.en.forEach((alias, index) => {
+                        addResult(`  ${index + 1}. ${alias.value}`, 'success');
+                    });
+                } else {
+                    addResult('No aliases found', 'error');
+                }
+                
+                // Test property that might have aliases
+                addResult('Fetching P31 (instance of)...');
+                const property = await client.fetchProperty('P31', 'en');
+                
+                if (property) {
+                    addResult(`Property ID: ${property.id}`, 'info');
+                    addResult(`Main label: ${property.labels?.en?.value || 'No label'}`, 'info');
+                    
+                    if (property.aliases && property.aliases.en) {
+                        addResult(`Found ${property.aliases.en.length} property aliases:`, 'success');
+                        property.aliases.en.forEach((alias, index) => {
+                            addResult(`  ${index + 1}. ${alias.value}`, 'success');
+                        });
+                    } else {
+                        addResult('No property aliases found', 'info');
+                    }
+                }
+                
+                addResult('Test completed!', 'success');
+                
+            } catch (error) {
+                addResult(`ERROR: ${error.message}`, 'error');
+                console.error(error);
+            }
+        }
+        
+        testAliases();
+    </script>
+</body>
+</html>

--- a/wikidata-api-browser.js
+++ b/wikidata-api-browser.js
@@ -52,7 +52,7 @@ class WikidataAPIClient {
   /**
    * Fetch entities from Wikidata API
    * @param {string|Array} ids - Entity IDs to fetch
-   * @param {string} props - Properties to fetch (labels|descriptions|claims)
+   * @param {string} props - Properties to fetch (labels|descriptions|claims|aliases)
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - API response
    */
@@ -80,7 +80,7 @@ class WikidataAPIClient {
    * @returns {Promise<Object>} - Entity data
    */
   async fetchEntity(entityId, languages = 'en') {
-    const data = await this.fetchEntities(entityId, 'labels|descriptions|claims', languages);
+    const data = await this.fetchEntities(entityId, 'labels|descriptions|claims|aliases', languages);
     return data.entities[entityId];
   }
 
@@ -102,7 +102,7 @@ class WikidataAPIClient {
    * @returns {Promise<Object>} - Property data
    */
   async fetchProperty(propertyId, languages = 'en') {
-    const data = await this.fetchEntities(propertyId, 'labels|descriptions|claims', languages);
+    const data = await this.fetchEntities(propertyId, 'labels|descriptions|claims|aliases', languages);
     return data.entities[propertyId];
   }
 

--- a/wikidata-api.js
+++ b/wikidata-api.js
@@ -53,7 +53,7 @@ class WikidataAPIClient {
   /**
    * Fetch entities from Wikidata API
    * @param {string|Array} ids - Entity IDs to fetch
-   * @param {string} props - Properties to fetch (labels|descriptions|claims)
+   * @param {string} props - Properties to fetch (labels|descriptions|claims|aliases)
    * @param {string} languages - Languages to fetch
    * @returns {Promise<Object>} - API response
    */
@@ -81,7 +81,7 @@ class WikidataAPIClient {
    * @returns {Promise<Object>} - Entity data
    */
   async fetchEntity(entityId, languages = 'en') {
-    const data = await this.fetchEntities(entityId, 'labels|descriptions|claims', languages);
+    const data = await this.fetchEntities(entityId, 'labels|descriptions|claims|aliases', languages);
     return data.entities[entityId];
   }
 
@@ -103,7 +103,7 @@ class WikidataAPIClient {
    * @returns {Promise<Object>} - Property data
    */
   async fetchProperty(propertyId, languages = 'en') {
-    const data = await this.fetchEntities(propertyId, 'labels|descriptions|claims', languages);
+    const data = await this.fetchEntities(propertyId, 'labels|descriptions|claims|aliases', languages);
     return data.entities[propertyId];
   }
 


### PR DESCRIPTION
## 🎯 Summary

Implements support for switching between alternative words/names for entities in the same language, allowing users to view and select from available aliases alongside the main label.

## 🚀 Features

- **API Enhancement**: Updated Wikidata API clients to fetch aliases alongside labels, descriptions, and claims
- **Interactive UI**: Added dropdown selector next to entity/property names when aliases are available  
- **State Management**: Proper state handling for selected label index with language change reset
- **Dual Support**: Works for both entities (`entities.html`) and properties (`properties.html`)
- **Backward Compatibility**: Maintains all existing functionality while adding new features

## 🔧 Technical Implementation

### API Changes
- Modified `fetchEntity()` and `fetchProperty()` to include `aliases` in the props parameter
- Updated both browser (`wikidata-api-browser.js`) and Node.js (`wikidata-api.js`) implementations

### UI Components
- Added aliases state management with React hooks
- Implemented label index selection with automatic reset on language change
- Created responsive dropdown with theme-aware styling
- Displays aliases with "(alias)" suffix for clear distinction

### Data Flow
1. Fetch entity/property data including aliases from Wikidata API
2. Build available labels array combining main label and aliases
3. Render dropdown when multiple options exist
4. Update display based on user selection

## 🧪 Testing

- Tested with Q35120 (entity) which has aliases "thing" and "object"
- Verified functionality across different languages
- Confirmed proper state management and UI updates
- Added test page (`test-aliases.html`) for development verification

## 📋 Implementation Details

The solution provides a seamless way to switch between:
- Main label (e.g., "entity")  
- Available aliases (e.g., "thing (alias)", "object (alias)")

Users can easily explore different names for the same concept, enhancing the semantic understanding capabilities of the Human Language project.

## ✅ Fixes

Closes #10 - Support switching between alternative words/names for entity in the same language

---
🤖 Generated with [Claude Code](https://claude.ai/code)