### PR TITLE
ci: build arm64 images on native runners

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -260,17 +260,79 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-docker:
-    name: Docker publish (ghcr.io)
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
+    name: Docker build (${{ matrix.arch }})
+    timeout-minutes: 20
     needs: [detect-version-bump, unit-tests]
     if: needs.detect-version-bump.outputs.should_publish == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/human-language
+          labels: |
+            org.opencontainers.image.version=${{ needs.detect-version-bump.outputs.version }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,scope=docker-${{ matrix.arch }},mode=max
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/human-language,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: human-language-digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-docker-manifest:
+    name: Docker publish (multi-platform manifest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [detect-version-bump, publish-docker]
+    if: needs.detect-version-bump.outputs.should_publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: human-language-digest-*
+          merge-multiple: true
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -285,21 +347,26 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=${{ needs.detect-version-bump.outputs.version }}
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ github.repository_owner }}/human-language@sha256:%s ' *)
+      - name: Verify both platforms were published
+        run: |
+          image="ghcr.io/${{ github.repository_owner }}/human-language:${{ needs.detect-version-bump.outputs.version }}"
+          docker buildx imagetools inspect --raw "$image" > /tmp/manifest.json
+          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")' /tmp/manifest.json
+          jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")' /tmp/manifest.json
 
   create-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [detect-version-bump, publish-npm, publish-docker]
+    # Registry availability must not withhold a release whose package passed
+    # every code and npm publication gate.
+    needs: [detect-version-bump, publish-npm]
     if: needs.detect-version-bump.outputs.should_publish == 'true'
     permissions:
       contents: write

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T09:56:31.353Z for PR creation at branch issue-40-ae4be77cf026 for issue https://github.com/link-assistant/human-language/issues/40

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T09:56:31.353Z for PR creation at branch issue-40-ae4be77cf026 for issue https://github.com/link-assistant/human-language/issues/40

--- a/js/scripts/run-unit-tests.mjs
+++ b/js/scripts/run-unit-tests.mjs
@@ -18,6 +18,7 @@ const FAST_SUITES = [
   'js/tests/unit/server.test.mjs',
   'js/tests/unit/cli.test.mjs',
   'js/tests/unit/qp-to-text.test.mjs',
+  'js/tests/unit/release-workflow.test.mjs',
 ];
 
 const INTEGRATION_SUITES = [

--- a/js/tests/unit/release-workflow.test.mjs
+++ b/js/tests/unit/release-workflow.test.mjs
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const workflow = await readFile('.github/workflows/js.yml', 'utf8');
+
+test('Docker images build on native amd64 and arm64 runners', () => {
+  assert.match(workflow, /platform: linux\/amd64\s+runner: ubuntu-latest/);
+  assert.match(workflow, /platform: linux\/arm64\s+runner: ubuntu-24\.04-arm/);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.doesNotMatch(workflow, /setup-qemu-action/);
+});
+
+test('architecture builds use isolated GitHub Actions caches and publish digests', () => {
+  assert.match(workflow, /cache-from: type=gha,scope=docker-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-to: type=gha,scope=docker-\$\{\{ matrix\.arch \}\},mode=max/);
+  assert.match(workflow, /outputs: type=image,name=ghcr\.io\/\$\{\{ github\.repository_owner \}\}\/human-language,push-by-digest=true,name-canonical=true,push=true/);
+  assert.match(workflow, /steps\.build\.outputs\.digest/);
+});
+
+test('published digests are merged and the multi-platform manifest is verified', () => {
+  assert.match(workflow, /needs: \[detect-version-bump, publish-docker\]/);
+  assert.match(workflow, /docker buildx imagetools create/);
+  assert.match(workflow, /docker buildx imagetools inspect/);
+  assert.match(workflow, /linux\/amd64/);
+  assert.match(workflow, /linux\/arm64/);
+});


### PR DESCRIPTION
## Summary

- build `linux/amd64` and `linux/arm64` images in parallel on native GitHub-hosted runners
- remove QEMU and add architecture-scoped GitHub Actions build caches
- publish immutable per-platform digests, merge them into `latest` and versioned manifests, and verify both target platforms
- create the GitHub Release after npm publication without making it depend on the container registry
- add a gating regression suite for the release workflow topology

## Reproduction

Before this change, `.github/workflows/js.yml` ran one multi-platform Buildx step on `ubuntu-latest`, included `docker/setup-qemu-action`, and had no `cache-from` or `cache-to` entries. The new regression test fails against that workflow.

## Tests

- `node --test js/tests/unit/release-workflow.test.mjs`
- `npm run test:syntax`
- `npm test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/js.yml`
- `cargo fmt --check`
- `cargo test --all-targets`
- `npm run test:e2e:local` (10 passed; 2 pre-existing live-Wikidata tests failed because Wikidata returned CORS / Failed to fetch errors)

Fixes #40
