### PR TITLE
fix(ci): fail releases unless the GHCR package is public

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -293,6 +293,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/human-language
           labels: |
             org.opencontainers.image.version=${{ needs.detect-version-bump.outputs.version }}
+            org.opencontainers.image.source=https://github.com/link-assistant/human-language
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -327,6 +328,7 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@v6
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -359,6 +361,10 @@ jobs:
           docker buildx imagetools inspect --raw "$image" > /tmp/manifest.json
           jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "amd64")' /tmp/manifest.json
           jq -e 'any(.manifests[]; .platform.os == "linux" and .platform.architecture == "arm64")' /tmp/manifest.json
+      - name: Verify the GHCR package is anonymously pullable
+        env:
+          GHCR_IMAGE: ghcr.io/link-assistant/human-language
+        run: bash scripts/verify-ghcr-visibility.sh
 
   create-release:
     name: Create GitHub release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-13T16:06:48.749Z for PR creation at branch issue-42-d8740450e119 for issue https://github.com/link-assistant/human-language/issues/42

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-13T16:06:48.749Z for PR creation at branch issue-42-d8740450e119 for issue https://github.com/link-assistant/human-language/issues/42

--- a/README.md
+++ b/README.md
@@ -268,6 +268,19 @@ node js/scripts/e2e-test.mjs
 node js/scripts/limitation-test.mjs
 ```
 
+### GHCR release bootstrap
+
+Docker publishing fails closed unless GHCR grants an anonymous pull token for
+`ghcr.io/link-assistant/human-language`. A package created by its first workflow
+push may initially be private. In that case, the publishing job fails with a
+`PRIVATE` error even though the image was pushed successfully.
+
+An organization owner must open the package's settings, select **Danger Zone →
+Change visibility → Public**, and rerun the failed job. GitHub does not provide
+an organization setting or API that can perform this one-time visibility
+change, so the workflow deliberately does not bypass the check with registry
+credentials.
+
 ### Interactive Demos
 
 See the [🎬 Demos](#-demos) section above for the full table — every demo is hosted at `https://link-assistant.github.io/human-language/<file>`.

--- a/js/scripts/run-unit-tests.mjs
+++ b/js/scripts/run-unit-tests.mjs
@@ -19,6 +19,7 @@ const FAST_SUITES = [
   'js/tests/unit/cli.test.mjs',
   'js/tests/unit/qp-to-text.test.mjs',
   'js/tests/unit/release-workflow.test.mjs',
+  'js/tests/unit/ghcr-visibility.test.mjs',
 ];
 
 const INTEGRATION_SUITES = [

--- a/js/tests/unit/ghcr-visibility.test.mjs
+++ b/js/tests/unit/ghcr-visibility.test.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { promisify } from 'node:util';
+import { test } from 'node:test';
+
+const execFileAsync = promisify(execFile);
+const script = 'scripts/verify-ghcr-visibility.sh';
+
+async function runProbe(
+  status,
+  image = 'ghcr.io/link-assistant/human-language',
+  token = 'super-secret-pull-token',
+) {
+  const sandbox = await mkdtemp(join(tmpdir(), 'human-language-ghcr-'));
+  const fakeCurl = join(sandbox, 'curl');
+  await writeFile(fakeCurl, `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$SANDBOX/calls.log"
+output=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then output="$2"; shift; fi
+  shift
+done
+if [ -n "$output" ]; then
+  printf '{"token":"%s"}\\n' "$FAKE_CURL_TOKEN" > "$output"
+fi
+if [ "$FAKE_CURL_STATUS" = transport ]; then exit 7; fi
+printf '%s' "$FAKE_CURL_STATUS"
+`);
+  await chmod(fakeCurl, 0o755);
+
+  let result;
+  try {
+    result = await execFileAsync('bash', [script], {
+      env: {
+        ...process.env,
+        PATH: `${sandbox}${delimiter}${process.env.PATH}`,
+        SANDBOX: sandbox,
+        FAKE_CURL_STATUS: status,
+        FAKE_CURL_TOKEN: token,
+        GHCR_IMAGE: image,
+        VERIFY_GHCR_VISIBILITY_DELAY: '0',
+      },
+    });
+  } catch (error) {
+    result = error;
+  }
+
+  const calls = await readFile(join(sandbox, 'calls.log'), 'utf8').catch(() => '');
+  await rm(sandbox, { recursive: true, force: true });
+  return { ...result, calls };
+}
+
+test('HTTP 200 proves anonymous pull access without exposing the token', async () => {
+  const result = await runProbe('200');
+
+  assert.equal(result.code, undefined, result.stderr);
+  assert.match(result.stdout, /is public/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /super-secret-pull-token/);
+  assert.equal(result.calls.trim().split('\n').length, 1);
+  assert.match(result.calls, /^-q -sS /);
+  assert.doesNotMatch(result.calls, /Authorization|GITHUB_TOKEN|--user|-u /);
+  assert.match(
+    result.calls,
+    /https:\/\/ghcr\.io\/token\?service=ghcr\.io&scope=repository:link-assistant\/human-language:pull/,
+  );
+});
+
+test('tag and digest suffixes are excluded from the repository scope', async () => {
+  for (const image of [
+    'ghcr.io/link-assistant/human-language:0.2.1',
+    'ghcr.io/link-assistant/human-language@sha256:0123456789abcdef',
+  ]) {
+    const result = await runProbe('200', image);
+    assert.match(
+      result.calls,
+      /scope=repository:link-assistant\/human-language:pull/,
+    );
+  }
+});
+
+test('HTTP 200 without a pull token fails closed', async () => {
+  const result = await runProbe('200', undefined, '');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /without an anonymous pull token/);
+});
+
+test('HTTP 401 fails closed and explains the one-time visibility bootstrap', async () => {
+  const result = await runProbe('401');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /PRIVATE/);
+  assert.match(result.stdout, /Change visibility/);
+});
+
+test('HTTP 403 fails as missing or denied', async () => {
+  const result = await runProbe('403');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /DENIED/);
+  assert.doesNotMatch(result.stdout, /PRIVATE/);
+});
+
+for (const status of ['503', 'transport']) {
+  test(`${status} failures exhaust the bounded retry budget`, async () => {
+    const result = await runProbe(status);
+
+    assert.equal(result.code, 1);
+    assert.equal(result.calls.trim().split('\n').length, 3);
+    assert.match(result.stdout, /after 3 attempt/);
+  });
+}
+
+test('unexpected statuses fail instead of passing by default', async () => {
+  const result = await runProbe('418');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /Unexpected HTTP 418/);
+});
+
+test('an unset image cannot silently pass', async () => {
+  const result = await runProbe('200', '');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /GHCR_IMAGE is not set/);
+  assert.equal(result.calls, '');
+});
+
+test('the probe is valid Bash', async () => {
+  await execFileAsync('bash', ['-n', script]);
+});
+
+test('the executable probe contains no credential plumbing', async () => {
+  const contents = await readFile(script, 'utf8');
+  const executable = contents
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+
+  for (const credential of ['Authorization', 'GITHUB_TOKEN', '--user', '-u ']) {
+    assert.doesNotMatch(executable, new RegExp(credential));
+  }
+});
+
+test('the manifest publishing path verifies visibility and source metadata', async () => {
+  const workflow = await readFile('.github/workflows/js.yml', 'utf8');
+  const manifestJob = workflow.split('\n  merge-docker-manifest:')[1]
+    .split('\n  create-release:')[0];
+  const createOffset = manifestJob.indexOf('- name: Create manifest list and push');
+  const verifyOffset = manifestJob.indexOf('bash scripts/verify-ghcr-visibility.sh');
+
+  assert.ok(createOffset >= 0);
+  assert.ok(verifyOffset > createOffset, 'anonymous verification must follow manifest creation');
+  assert.match(manifestJob, /actions\/checkout@v6/);
+  assert.match(
+    workflow,
+    /org\.opencontainers\.image\.source=https:\/\/github\.com\/link-assistant\/human-language/,
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-language",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-language",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "lino-arguments": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "human-language",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Human Language: a Wikidata-backed library, CLI and HTTP microservice for transforming English text into sequences of Wikidata entities (Q) and properties (P), with alphabet/dictionary/ontology browsing and IPA support.",
   "license": "MIT",
   "repository": {

--- a/research/abstract-wikipedia-analysis.md
+++ b/research/abstract-wikipedia-analysis.md
@@ -316,6 +316,6 @@ Fresh research gathered June 2026:
 - [Natural language generation system architecture proposal — Meta-Wiki](https://meta.wikimedia.org/wiki/Abstract_Wikipedia/Natural_language_generation_system_architecture_proposal) (6-stage NLG pipeline)
 - [Wikifunctions:Abstract Wikipedia/2025 fragment experiments](https://www.wikifunctions.org/wiki/Wikifunctions:Abstract_Wikipedia/2025_fragment_experiments) (semantic fragments, `Z26039`, UN 6 languages)
 - [Wikifunctions:NLG SIG](https://www.wikifunctions.org/wiki/Wikifunctions:NLG_SIG) (Natural Language Generation Special Interest Group)
-- [Using Wikidata Lexemes and Items to Generate Text from Abstract Representations — Mahir Morshed, 2024 (Semantic Web Journal)](https://content.iospress.com/articles/semantic-web/sw243564) (Ninai/Udiron, constructors, renderers)
+- [Using Wikidata Lexemes and Items to Generate Text from Abstract Representations — Mahir Morshed, 2024 (Semantic Web Journal)](https://www.semantic-web-journal.net/content/using-wikidata-lexemes-and-items-generate-text-abstract-representations-0) (Ninai/Udiron, constructors, renderers)
 - [Abstract Wikipedia/Google.org Fellows evaluation — Meta-Wiki](https://meta.wikimedia.org/wiki/Abstract_Wikipedia/Google.org_Fellows_evaluation) (risk-of-failure assessment)
 - [Wikifunctions status updates (2025)](https://www.wikifunctions.org/wiki/Wikifunctions:Status_updates/2025-06-21)

--- a/scripts/verify-ghcr-visibility.sh
+++ b/scripts/verify-ghcr-visibility.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verify that GHCR grants an anonymous pull token for the package just pushed.
+# Deliberately do not add credentials: authenticated access would make a private
+# package look public and defeat this release gate.
+set -euo pipefail
+
+GHCR_IMAGE="${GHCR_IMAGE:-}"
+GHCR_TOKEN_ENDPOINT="${GHCR_TOKEN_ENDPOINT:-https://ghcr.io/token}"
+retries="${VERIFY_GHCR_VISIBILITY_RETRIES:-3}"
+delay="${VERIFY_GHCR_VISIBILITY_DELAY:-5}"
+
+if [ -z "$GHCR_IMAGE" ]; then
+  echo "::error::GHCR_IMAGE is not set; nothing to verify"
+  exit 1
+fi
+
+repository="${GHCR_IMAGE#ghcr.io/}"
+repository="${repository%%@*}"
+repository="${repository%%:*}"
+url="${GHCR_TOKEN_ENDPOINT}?service=ghcr.io&scope=repository:${repository}:pull"
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+attempt=1
+while :; do
+  status="000"
+  # -q must be first: ignore user curl configuration that could add credentials.
+  if response_status="$(curl -q -sS -o "$body" -w '%{http_code}' "$url")"; then
+    status="$response_status"
+  fi
+
+  case "$status" in
+    200)
+      if ! grep -Eq '"token"[[:space:]]*:[[:space:]]*"[^"]+"' "$body"; then
+        echo "::error::GHCR returned HTTP 200 without an anonymous pull token for ${GHCR_IMAGE}"
+        exit 1
+      fi
+      echo "OK: ${GHCR_IMAGE} is public (GHCR issued an anonymous pull token)"
+      exit 0
+      ;;
+    401)
+      echo "::error::${GHCR_IMAGE} is PRIVATE; anonymous pulls are unauthorized."
+      echo "An organization owner must open the package settings, choose Danger Zone -> Change visibility -> Public, then rerun this job."
+      exit 1
+      ;;
+    403)
+      echo "::error::${GHCR_IMAGE} is missing or DENIED to anonymous callers; the push may not have completed."
+      exit 1
+      ;;
+    000 | 5??)
+      if [ "$attempt" -ge "$retries" ]; then
+        echo "::error::The GHCR token endpoint failed for ${GHCR_IMAGE} (last status ${status}) after ${retries} attempt(s)"
+        exit 1
+      fi
+      attempt=$((attempt + 1))
+      sleep "$delay"
+      ;;
+    *)
+      echo "::error::Unexpected HTTP ${status} from the GHCR token endpoint for ${GHCR_IMAGE}"
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
## Summary

- add a credential-free GHCR token-endpoint probe after multi-platform manifest creation
- accept only HTTP 200 with a non-empty anonymous pull token; fail closed on 401, 403, malformed 200 responses, and unexpected statuses
- retry transport failures and HTTP 5xx responses three times
- attach the repository source OCI label to both architecture images
- document the one-time owner bootstrap for a newly created private package
- bump the JS package to 0.2.1 so the version-gated release path exercises the fix
- replace a bot-blocked IOS Press citation with the journal's stable article record so the existing link check remains reliable

## Root cause and reproduction

The existing manifest inspection runs after `docker/login-action`, so it proves only that the publishing identity can read the image. It can remain green when anonymous users cannot pull a private package.

The regression suite puts a fake `curl` first on `PATH`, reproducing the private-package response without network access. HTTP 401 now makes the script exit 1 and print the manual visibility remedy. A live credential-free probe during development returned HTTP 200 with an anonymous token, confirming the package is currently public.

## Tests

- `node --test js/tests/unit/ghcr-visibility.test.mjs` (12 passed)
- `npm run test:syntax`
- `npm test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/js.yml`
- `npm pack --dry-run`
- `cargo fmt --manifest-path rust/Cargo.toml --check`
- `cargo test --manifest-path rust/Cargo.toml --all-targets` (33 passed)
- `npm run test:e2e:local` (9 passed; 3 existing live-Wikidata cases failed on CORS / `Failed to fetch`)
- GitHub Actions run 31720192335: link check, syntax, unit, and Playwright E2E jobs passed

Fixes #42
